### PR TITLE
fixed a typo in dependency string

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ This library requires Spark 1.2+
 You can link against this library in your program at the following coordiates:
 
 ```
-groupId: com.databricks.spark
+groupId: com.databricks
 artifactId: spark-avro_2.10
 version: 0.1
 ```
 
-Using SBT: `libraryDependencies += "com.databricks.spark" %% "spark-avro" % "0.1"`
+Using SBT: `libraryDependencies += "com.databricks" %% "spark-avro" % "0.1"`
 
 <!---
 TODO: Add a link to download the JAR directly for e.g. adding to the Spark shell


### PR DESCRIPTION
According to [this page](http://search.maven.org/#artifactdetails%7Ccom.databricks%7Cspark-avro_2.10%7C0.1%7Cjar) and build.sbt there is a typo in groupId.
