### PR TITLE
Throw better error when invalid path is provided

### DIFF
--- a/src/main/scala/com/databricks/spark/avro/AvroRelation.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroRelation.scala
@@ -15,6 +15,7 @@
  */
 package com.databricks.spark.avro
 
+import java.io.FileNotFoundException
 import java.nio.ByteBuffer
 import java.util.Map
 
@@ -74,7 +75,13 @@ case class AvroRelation(location: String)(@transient val sqlContext: SQLContext)
   private def newReader() = {
     val path = new Path(location)
     val fs = FileSystem.get(path.toUri, sqlContext.sparkContext.hadoopConfiguration)
-    val statuses = fs.globStatus(path)
+    val globStatus = fs.globStatus(path)
+
+    if (globStatus == null) {
+      throw new FileNotFoundException(s"The path you've provided ($location) is invalid.")
+    }
+
+    val statuses = globStatus
       .toStream
       .map(_.getPath)
       .flatMap(getAllFiles(fs)(_))

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -15,6 +15,7 @@
  */
 package com.databricks.spark.avro
 
+import java.io.FileNotFoundException
 import java.sql.Timestamp
 
 import scala.collection.mutable.ArrayBuffer
@@ -224,5 +225,17 @@ class AvroSuite extends FunSuite {
       .avroFile("src/*/*/episodes.avro")
       .collect()
     assert(e2.size == 8)
+  }
+
+  test("reading from invalid path throws exception") {
+    intercept[FileNotFoundException] {
+      TestSQLContext.avroFile("very/invalid/path/123.avro")
+    }
+
+    // In case of globbed path that can't be matched to anything, another exception is thrown (and
+    // exception message is helpful)
+    intercept[RuntimeException] {
+      TestSQLContext.avroFile("*/*/*/*/*/*/*/something.avro")
+    }
   }
 }


### PR DESCRIPTION
The PR for globbed paths made errors for invalid paths very unclear. Here is the exception that you get when invalid path is provided:

```scala> val students = sqlContext.avroFile("/wut/is/this/invalidName.avro")
java.lang.NullPointerException
	at scala.collection.mutable.ArrayOps$ofRef$.length$extension(ArrayOps.scala:114)
	at scala.collection.mutable.ArrayOps$ofRef.length(ArrayOps.scala:114)
	at scala.collection.IndexedSeqLike$class.iterator(IndexedSeqLike.scala:91)```

Which is not very helpful. This PR adds explicit error message for invalid path:

```scala> val students = sqlContext.avroFile("/wut/is/this/invalidName.avro")
java.io.FileNotFoundException: The path you've provided (/wut/da/fu.avro) is invalid.
	at com.databricks.spark.avro.AvroRelation.newReader(AvroRelation.scala:78)
	at com.databricks.spark.avro.AvroRelation.<init>(AvroRelation.scala:44)```