### PR TITLE
Style and README cleanup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Using SBT: `libraryDependencies += "com.databricks" %% "spark-avro" % "1.0.0"`
 TODO: Add a link to download the JAR directly for e.g. adding to the Spark shell
 --->
 
-The spark-avro jar file can also be added to a Spark using the `--jars` command line option.  For example, to include it when starting the spark shell:
+The spark-avro jar file can also be added to a Spark using the `--jars` command line option.
+For example, to include it when starting the spark shell:
 
 ```
 $ bin/spark-shell --jars spark-avro_2.10-1.0.0.jar
@@ -32,14 +33,16 @@ $ bin/spark-shell --jars spark-avro_2.10-1.0.0.jar
 For use with Spark 1.2, you can use version `0.2.0` instead.
 
 ## Features
-These examples use an avro file available for download [here](https://github.com/databricks/spark-avro/raw/master/src/test/resources/episodes.avro):
+These examples use an avro file available for download
+[here](https://github.com/databricks/spark-avro/raw/master/src/test/resources/episodes.avro):
 
 ```
 $ wget https://github.com/databricks/spark-avro/raw/master/src/test/resources/episodes.avro
 ```
 
 ## Supported types for Avro -> SparkSQL conversion
-As of now, every avro type with the exception of complex unions is supported. To be more specific, we use the following mapping from avro types to SparkSQL types:
+As of now, every avro type with the exception of complex unions is supported. To be more specific,
+we use the following mapping from avro types to SparkSQL types:
 
 ```
 boolean -> BooleanType
@@ -62,13 +65,15 @@ As for unions, we only support three kinds of unions:
 
 2) union(float, double)
 
-3) union(something, null), where something is one of the avro types mentioned above, including two types of unions.
+3) union(something, null), where something is one of the avro types mentioned above, including
+two types of unions.
 
 At the moment we ignore docs, aliases and other properties present in the avro file.
 
 ## Supported types for SparkSQL -> Avro conversion
 
-Every SparkSQL type is supported. For most of them the corresponding type is obvious (e.g. IntegerType gets converted to int), for the rest the following conversions are used:
+Every SparkSQL type is supported. For most of them the corresponding type is obvious
+(e.g. IntegerType gets converted to int), for the rest the following conversions are used:
 
 ```
 ByteType -> int
@@ -81,9 +86,10 @@ StructType -> record
 
 ### Scala API
 
-A recommended way to read query Avro data in sparkSQL, or save sparkSQL data as Avro is by using native DataFrame APIs (available in Scala, Java and Python, starting from Spark 1.3):
+A recommended way to read query Avro data in sparkSQL, or save sparkSQL data as Avro is by using
+native DataFrame APIs (available in Scala, Java and Python, starting from Spark 1.3):
 
-```
+```scala
 import org.apache.spark.sql._
 val sqlContext = new SQLContext(sc)
 // Creates a DataFrame from a specified file
@@ -94,7 +100,7 @@ df.save("/new/dir/", "com.databricks.spark.avro")
 
 An alternative way is to use `avroFile` and `save` methods (available in 1.2+):
 
-```
+```scala
 scala> import org.apache.spark.sql.SQLContext
 
 scala> val sqlContext = new SQLContext(sc)
@@ -118,20 +124,39 @@ res0: Array[org.apache.spark.sql.Row] = Array([The Eleventh Hour], [The Doctor's
 `avroFile` allows you to specify the `minPartitions` parameter as its second argument.
 To save DataFrame as avro you should use the `save` method in `AvroSaver`. For example:
 
-```
+```scala
 scala> AvroSaver.save(myRDD, "my/output/dir")
 ```
 
-We also support the ability to read all avro files from some directory. To do that, you can pass a path to that directory to the avroFile() function. However, there is a limitation - all of those files must have the same schema. Additionally, files used must have a .avro extension.
+We also support the ability to read all avro files from some directory. To do that, you can pass
+a path to that directory to the avroFile() function. However, there is a limitation - all of
+those files must have the same schema. Additionally, files used must have a .avro extension.
+
+
+### Java API
+
+The recommended way to query avro is to use the native DataFrame APIs.
+The code is almost identical to Scala:
+
+```java
+import org.apache.spark.sql.*;
+SQLContext sqlContext = new SQLContext(sc);
+// Creates a DataFrame from a specified file
+DataFrame df = sqlContext.load("src/test/resources/episodes.avro", "com.databricks.spark.avro");
+// Saves df to /new/dir/ as avro files
+df.save("/new/dir/", "com.databricks.spark.avro");
+```
+
 
 ### Python API
 
-As mentioned before, a recommended way to query avro is to use native DataFrame APIs. The code is almost identical to Scala:
+As mentioned before, a recommended way to query avro is to use native DataFrame APIs.
+The code is almost identical to Scala:
 
-```
-// Creates a DataFrame from a specified file
+```python
+# Creates a DataFrame from a specified file
 df = sqlContext.load("src/test/resources/episodes.avro", "com.databricks.spark.avro")
-// Saves df to /new/dir/ as avro files
+# Saves df to /new/dir/ as avro files
 df.save("/new/dir/", "com.databricks.spark.avro")
 ```
 
@@ -144,16 +169,26 @@ USING com.databricks.spark.avro
 OPTIONS (path "src/test/resources/episodes.avro")
 ```
 
+
 ## Building From Source
-This library is built with [SBT](http://www.scala-sbt.org/0.13/docs/Command-Line-Reference.html), which is automatically downloaded by the included shell script.  To build a JAR file simply run `sbt/sbt package` from the project root.
+This library is built with [SBT](http://www.scala-sbt.org/0.13/docs/Command-Line-Reference.html),
+which is automatically downloaded by the included shell script.  To build a JAR file simply run
+`sbt/sbt package` from the project root.
 
 ## Testing
-To run the tests, you should run `sbt/sbt test`. In case you are doing improvements that target speed, you can generate a sample avro file and check how long does it take to read that avro file using the following commands:
+To run the tests, you should run `sbt/sbt test`. In case you are doing improvements that target
+speed, you can generate a sample avro file and check how long does it take to read that avro file
+using the following commands:
 
-`sbt/sbt "test:run-main com.databricks.spark.avro.AvroFileGenerator NUMBER_OF_RECORDS NUMBER_OF_FILES"` will create sample avro files in `target/avroForBenchmark/`. You can specify the number of records for each file, as well as the overall number of files.
+`sbt/sbt "test:run-main com.databricks.spark.avro.AvroFileGenerator NUMBER_OF_RECORDS NUMBER_OF_FILES"`
+will create sample avro files in `target/avroForBenchmark/`. You can specify the number of records
+for each file, as well as the overall number of files.
 
-`sbt/sbt "test:run-main com.databricks.spark.avro.AvroReadBenchmark"` runs `count()` on the data inside `target/avroForBenchmark/` and tells you how long did the operation take.
+`sbt/sbt "test:run-main com.databricks.spark.avro.AvroReadBenchmark"` runs `count()` on the data
+inside `target/avroForBenchmark/` and tells you how long did the operation take.
 
 Similarly, you can do benchmarks on how long does it take to write DataFrame as avro file with:
 
- `sbt/sbt "test:run-main com.databricks.spark.avro.AvroWriteBenchmark NUMBER_OF_ROWS"`, where `NUMBER_OF_ROWS` is an optional parameter that allows you to specify the number of rows in DataFrame that we will be writing.
+`sbt/sbt "test:run-main com.databricks.spark.avro.AvroWriteBenchmark NUMBER_OF_ROWS"`, where
+`NUMBER_OF_ROWS` is an optional parameter that allows you to specify the number of rows in
+DataFrame that we will be writing.

--- a/src/main/scala/com/databricks/spark/avro/AvroRelation.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroRelation.scala
@@ -23,7 +23,7 @@ import scala.collection.JavaConversions._
 
 import org.apache.avro.file.DataFileReader
 import org.apache.avro.generic.GenericData
-import org.apache.avro.generic.GenericData.{Fixed, Record}
+import org.apache.avro.generic.GenericData.Fixed
 import org.apache.avro.generic.{GenericRecord, GenericDatumReader}
 import org.apache.avro.mapred.FsInput
 import org.apache.avro.{SchemaBuilder, Schema}
@@ -31,6 +31,7 @@ import org.apache.avro.Schema.Type._
 
 import org.apache.hadoop.fs.{FileSystem, Path}
 
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.sources.{BaseRelation, InsertableRelation, TableScan}
@@ -43,7 +44,7 @@ case class AvroRelation(
   extends BaseRelation with TableScan with InsertableRelation {
   var avroSchema: Schema = null
 
-  override val schema = {
+  override val schema: StructType = {
     if (userSpecifiedSchema.isDefined) {
       // We need avroSchema to construct converter
       avroSchema = SchemaConverters.convertStructToAvro(userSpecifiedSchema.get,
@@ -65,7 +66,7 @@ case class AvroRelation(
     }
   }
 
-  override def buildScan = {
+  override def buildScan(): RDD[Row] = {
     val minPartitionsNum = if (minPartitions <= 0) {
       sqlContext.sparkContext.defaultMinPartitions
     } else {

--- a/src/main/scala/com/databricks/spark/avro/AvroSaver.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroSaver.scala
@@ -62,8 +62,7 @@ object AvroSaver {
       rows: Iterator[Row],
       schema: StructType): Iterator[(AvroKey[GenericRecord], NullWritable)] = {
     val converter = createConverter(schema, "topLevelRecord")
-    rows.map(x => (new AvroKey(converter(x).asInstanceOf[GenericRecord]),
-      NullWritable.get())).toIterator
+    rows.map(x => (new AvroKey(converter(x).asInstanceOf[GenericRecord]), NullWritable.get()))
   }
 
   /**
@@ -137,8 +136,8 @@ object AvroSaver {
             val rowIterator = item.asInstanceOf[Row].toSeq.iterator
 
             while (convertersIterator.hasNext) {
-              val converter = convertersIterator.next
-              record.put(fieldNamesIterator.next, converter(rowIterator.next))
+              val converter = convertersIterator.next()
+              record.put(fieldNamesIterator.next(), converter(rowIterator.next()))
             }
             record
           }

--- a/src/test/scala/com/databricks/spark/avro/AvroFileGenerator.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroFileGenerator.scala
@@ -45,8 +45,8 @@ object AvroFileGenerator {
     while (idx < numberOfRecords) {
       avroRec.put("string", rand.nextString(objectSize))
       avroRec.put("simple_map", TestUtils.generateRandomMap(rand, objectSize))
-      avroRec.put("union_int_long_null", rand.nextInt)
-      avroRec.put("union_float_double", rand.nextDouble)
+      avroRec.put("union_int_long_null", rand.nextInt())
+      avroRec.put("union_float_double", rand.nextDouble())
       avroRec.put("inner_record", innerRec)
       avroRec.put("array_of_boolean", TestUtils.generateRandomArray(rand, objectSize))
       avroRec.put("bytes", generateRandomByteBuffer(rand))

--- a/src/test/scala/com/databricks/spark/avro/AvroReadBenchmark.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroReadBenchmark.scala
@@ -31,6 +31,6 @@ object AvroReadBenchmark {
 
     println(s"\n\n\nFinished benchmark test - result was $executionTime seconds\n\n\n")
 
-    TestSQLContext.sparkContext.stop // Otherwise scary exception message appears
+    TestSQLContext.sparkContext.stop()  // Otherwise scary exception message appears
   }
 }

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -99,7 +99,7 @@ private[avro] object TestUtils {
   private[avro] def generateRandomArray(rand: Random, size: Int): ArrayList[Boolean] = {
     val vec = new ArrayList[Boolean]()
     for (i <- 0 until size) {
-      vec.add(rand.nextBoolean)
+      vec.add(rand.nextBoolean())
     }
     vec
   }

--- a/src/test/scala/com/databricks/spark/avro/AvroWriteBenchmark.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroWriteBenchmark.scala
@@ -33,9 +33,9 @@ object AvroWriteBenchmark {
 
   private def generateRandomRow(): Row = {
     val rand = new Random()
-    Row(rand.nextString(defaultSize), rand.nextInt, rand.nextDouble, rand.nextDouble,
+    Row(rand.nextString(defaultSize), rand.nextInt(), rand.nextDouble(), rand.nextDouble(),
       TestUtils.generateRandomArray(rand, defaultSize).toSeq,
-      TestUtils.generateRandomMap(rand, defaultSize).toMap, Row(rand.nextInt))
+      TestUtils.generateRandomMap(rand, defaultSize).toMap, Row(rand.nextInt()))
   }
 
   private def createLargeRDD(numberOfRows: Int): RDD[Row] = {
@@ -66,6 +66,6 @@ object AvroWriteBenchmark {
     println(s"\n\n\nFinished benchmark test - result was $executionTime seconds\n\n\n")
 
     TestUtils.deleteRecursively(tempDir)
-    TestSQLContext.sparkContext.stop // Otherwise scary exception message appears
+    TestSQLContext.sparkContext.stop()  // Otherwise scary exception message appears
   }
 }


### PR DESCRIPTION
The Python code example in README was actually wrong (it was using // for comment).