### PR TITLE
Updated avro saving functionality to allow record name and namespace to ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ To save DataFrame as avro you should use the `save` method in `AvroSaver`. For e
 ```scala
 scala> AvroSaver.save(myRDD, "my/output/dir")
 ```
+You can also specifiy the the record name and namespace with optional parameters:
+```scala
+scala> AvroSaver.save(myRDD, "my/output/dir", Map("recordName" -> "MyRecord", "recordNamespace" -> "com.mycompany.mystuff"))
+```
 
 We also support the ability to read all avro files from some directory. To do that, you can pass
 a path to that directory to the avroFile() function. However, there is a limitation - all of

--- a/src/main/scala/com/databricks/spark/avro/AvroRelation.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroRelation.scala
@@ -40,7 +40,9 @@ import org.apache.spark.sql.sources.{BaseRelation, InsertableRelation, TableScan
 case class AvroRelation(
     location: String,
     userSpecifiedSchema: Option[StructType],
-    minPartitions: Int = 0) (@transient val sqlContext: SQLContext)
+    minPartitions: Int = 0,
+    recordName: String = "topLevelRecord",
+    recordNamespace: String = "") (@transient val sqlContext: SQLContext)
   extends BaseRelation with TableScan with InsertableRelation {
   var avroSchema: Schema = null
 
@@ -48,7 +50,7 @@ case class AvroRelation(
     if (userSpecifiedSchema.isDefined) {
       // We need avroSchema to construct converter
       avroSchema = SchemaConverters.convertStructToAvro(userSpecifiedSchema.get,
-        SchemaBuilder.record("topLevelRecord"))
+        SchemaBuilder.record(recordName).namespace(recordNamespace), recordNamespace)
       userSpecifiedSchema.get
     } else {
       val fileReader = newReader()

--- a/src/main/scala/com/databricks/spark/avro/AvroRelation.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroRelation.scala
@@ -20,6 +20,7 @@ import java.nio.ByteBuffer
 import java.util.Map
 
 import scala.collection.JavaConversions._
+import scala.collection.immutable.{Map => ScalaMap}
 
 import org.apache.avro.file.DataFileReader
 import org.apache.avro.generic.GenericData
@@ -41,8 +42,9 @@ case class AvroRelation(
     location: String,
     userSpecifiedSchema: Option[StructType],
     minPartitions: Int = 0,
-    recordName: String = "topLevelRecord",
-    recordNamespace: String = "") (@transient val sqlContext: SQLContext)
+    recordName: String = AvroSaver.defaultParameters.get("recordName").get,
+    recordNamespace: String = AvroSaver.defaultParameters.get("recordNamespace").get)
+                       (@transient val sqlContext: SQLContext)
   extends BaseRelation with TableScan with InsertableRelation {
   var avroSchema: Schema = null
 
@@ -241,7 +243,9 @@ case class AvroRelation(
               + s" to INSERT OVERWRITE a AVRO table:", e)
       }
       // Write the data.
-      data.saveAsAvroFile(location)
+      data.saveAsAvroFile(
+        location,
+        ScalaMap("recordName" -> recordName, "recordNamespace" -> recordNamespace))
       // Right now, we assume that the schema is not changed. We will not update the schema.
       // schema = data.schema
     } else {

--- a/src/main/scala/com/databricks/spark/avro/AvroSaver.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroSaver.scala
@@ -44,18 +44,23 @@ import org.apache.hadoop.mapred.JobConf
  */
 object AvroSaver {
 
-  def save(dataFrame: DataFrame, location: String, recordName: String = "topLevelRecord", recordNamespace: String = ""): Unit = {
+  def save(
+      dataFrame: DataFrame,
+      location: String,
+      recordName: String = "topLevelRecord",
+      recordNamespace: String = ""): Unit = {
     val jobConf = new JobConf(dataFrame.sqlContext.sparkContext.hadoopConfiguration)
     val builder = SchemaBuilder.record(recordName).namespace(recordNamespace)
     val schema = dataFrame.schema
     val avroSchema = SchemaConverters.convertStructToAvro(schema, builder, recordNamespace)
     AvroJob.setOutputSchema(jobConf, avroSchema)
 
-    dataFrame.mapPartitions(rowsToAvro(_, schema, recordName, recordNamespace)).saveAsHadoopFile(location,
-      classOf[AvroWrapper[GenericRecord]],
-      classOf[NullWritable],
-      classOf[AvroOutputFormat[GenericRecord]],
-      jobConf)
+    dataFrame.mapPartitions(rowsToAvro(_, schema, recordName, recordNamespace))
+      .saveAsHadoopFile(location,
+        classOf[AvroWrapper[GenericRecord]],
+        classOf[NullWritable],
+        classOf[AvroOutputFormat[GenericRecord]],
+        jobConf)
   }
 
   private def rowsToAvro(
@@ -71,7 +76,10 @@ object AvroSaver {
    * This function constructs converter function for a given sparkSQL datatype. These functions
    * will be used to convert dataFrame to avro format.
    */
-  def createConverter(dataType: DataType, structName: String, recordNamespace: String): (Any) => Any = {
+  def createConverter(
+      dataType: DataType,
+      structName: String,
+      recordNamespace: String): (Any) => Any = {
     dataType match {
       case ByteType | ShortType | IntegerType | LongType | FloatType | DoubleType | StringType |
            BinaryType | BooleanType =>

--- a/src/main/scala/com/databricks/spark/avro/AvroSaver.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroSaver.scala
@@ -40,15 +40,26 @@ import org.apache.hadoop.mapred.JobConf
  * doesn't have a name associated with it, we are taking the name of the last structure field that
  * the current structure is a child of. For example if the row at the top level had a field called
  * "X", which happens to be a structure, we would call that structure "X". When we process original
- * rows, they get a name "topLevelRecord".
+ * rows, you can give them a name and namespace by passing in a parameters map that gives the name
+ * and namespace. For example parameters = Map("recordName" -> "MyRecordName", "recordNamespace"
+ * -> "com.mycompany.records"). If no parameters are passed in the original rows get a name
+ * "topLevelRecord".
  */
 object AvroSaver {
+
+  val defaultParameters = Map("recordName" -> "topLevelRecord", "recordNamespace" -> "")
 
   def save(
       dataFrame: DataFrame,
       location: String,
-      recordName: String = "topLevelRecord",
-      recordNamespace: String = ""): Unit = {
+      parameters: Map[String, String] = defaultParameters): Unit = {
+    val recordName = parameters.getOrElse(
+      "recordName",
+      defaultParameters.get("recordName").get)
+    val recordNamespace = parameters.getOrElse(
+      "recordNamespace",
+      defaultParameters.get("recordNamespace").get)
+
     val jobConf = new JobConf(dataFrame.sqlContext.sparkContext.hadoopConfiguration)
     val builder = SchemaBuilder.record(recordName).namespace(recordNamespace)
     val schema = dataFrame.schema

--- a/src/main/scala/com/databricks/spark/avro/AvroSaver.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroSaver.scala
@@ -44,14 +44,14 @@ import org.apache.hadoop.mapred.JobConf
  */
 object AvroSaver {
 
-  def save(dataFrame: DataFrame, location: String): Unit = {
+  def save(dataFrame: DataFrame, location: String, recordName: String = "topLevelRecord", recordNamespace: String = ""): Unit = {
     val jobConf = new JobConf(dataFrame.sqlContext.sparkContext.hadoopConfiguration)
-    val builder = SchemaBuilder.record("topLevelRecord")
+    val builder = SchemaBuilder.record(recordName).namespace(recordNamespace)
     val schema = dataFrame.schema
-    val avroSchema = SchemaConverters.convertStructToAvro(schema, builder)
+    val avroSchema = SchemaConverters.convertStructToAvro(schema, builder, recordNamespace)
     AvroJob.setOutputSchema(jobConf, avroSchema)
 
-    dataFrame.mapPartitions(rowsToAvro(_, schema)).saveAsHadoopFile(location,
+    dataFrame.mapPartitions(rowsToAvro(_, schema, recordName, recordNamespace)).saveAsHadoopFile(location,
       classOf[AvroWrapper[GenericRecord]],
       classOf[NullWritable],
       classOf[AvroOutputFormat[GenericRecord]],
@@ -60,8 +60,10 @@ object AvroSaver {
 
   private def rowsToAvro(
       rows: Iterator[Row],
-      schema: StructType): Iterator[(AvroKey[GenericRecord], NullWritable)] = {
-    val converter = createConverter(schema, "topLevelRecord")
+      schema: StructType,
+      recordName: String,
+      recordNamespace: String): Iterator[(AvroKey[GenericRecord], NullWritable)] = {
+    val converter = createConverter(schema, recordName, recordNamespace )
     rows.map(x => (new AvroKey(converter(x).asInstanceOf[GenericRecord]), NullWritable.get()))
   }
 
@@ -69,7 +71,7 @@ object AvroSaver {
    * This function constructs converter function for a given sparkSQL datatype. These functions
    * will be used to convert dataFrame to avro format.
    */
-  def createConverter(dataType: DataType, structName: String): (Any) => Any = {
+  def createConverter(dataType: DataType, structName: String, recordNamespace: String): (Any) => Any = {
     dataType match {
       case ByteType | ShortType | IntegerType | LongType | FloatType | DoubleType | StringType |
            BinaryType | BooleanType =>
@@ -84,7 +86,7 @@ object AvroSaver {
         }
 
       case ArrayType(elementType, _) =>
-        val elementConverter = createConverter(elementType, structName)
+        val elementConverter = createConverter(elementType, structName, recordNamespace)
 
         (item: Any) => {
           if (item == null) {
@@ -105,7 +107,7 @@ object AvroSaver {
         }
 
       case MapType(StringType, valueType, _) =>
-        val valueConverter = createConverter(valueType, structName)
+        val valueConverter = createConverter(valueType, structName, recordNamespace)
 
         (item: Any) => {
           if (item == null) {
@@ -120,11 +122,11 @@ object AvroSaver {
         }
 
       case structType: StructType =>
-        val builder = SchemaBuilder.record(structName)
+        val builder = SchemaBuilder.record(structName).namespace(recordNamespace)
         val schema: Schema = SchemaConverters.convertStructToAvro(
-          structType, builder)
+          structType, builder, recordNamespace)
         val fieldConverters = structType.fields.map(field =>
-          createConverter(field.dataType, field.name))
+          createConverter(field.dataType, field.name, recordNamespace))
 
         (item: Any) => {
           if (item == null) {

--- a/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
@@ -55,8 +55,12 @@ class DefaultSource
       parameters: Map[String, String],
       data: DataFrame): BaseRelation = {
     val path = parameters("path")
-    val recordName = parameters.getOrElse("recordName", "topLevelRecord")
-    val recordNamespace = parameters.getOrElse("recordNamespace", "")
+    val recordName = parameters.getOrElse(
+      "recordName",
+      AvroSaver.defaultParameters.get("recordName").get)
+    val recordNamespace = parameters.getOrElse(
+      "recordNamespace",
+      AvroSaver.defaultParameters.get("recordNamespace").get)
     val filesystemPath = new Path(path)
     val fs = filesystemPath.getFileSystem(sqlContext.sparkContext.hadoopConfiguration)
     val doSave = if (fs.exists(filesystemPath)) {
@@ -77,7 +81,9 @@ class DefaultSource
 
     if (doSave) {
       // Only save data when the save mode is not ignore.
-      data.saveAsAvroFile(path, recordName, recordNamespace)
+      data.saveAsAvroFile(
+        path,
+        Map("recordName" -> recordName, "recordNamespace" -> recordNamespace))
     }
 
     createRelation(sqlContext, parameters, data.schema)

--- a/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
@@ -55,6 +55,8 @@ class DefaultSource
       parameters: Map[String, String],
       data: DataFrame): BaseRelation = {
     val path = parameters("path")
+    val recordName = parameters.getOrElse("recordName", "topLevelRecord")
+    val recordNamespace = parameters.getOrElse("recordNamespace", "")
     val filesystemPath = new Path(path)
     val fs = filesystemPath.getFileSystem(sqlContext.sparkContext.hadoopConfiguration)
     val doSave = if (fs.exists(filesystemPath)) {
@@ -75,7 +77,7 @@ class DefaultSource
 
     if (doSave) {
       // Only save data when the save mode is not ignore.
-      data.saveAsAvroFile(path)
+      data.saveAsAvroFile(path, recordName, recordNamespace)
     }
 
     createRelation(sqlContext, parameters, data.schema)

--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -94,15 +94,16 @@ private object SchemaConverters {
    */
   private[avro] def convertStructToAvro[T](
       structType: StructType,
-      schemaBuilder: RecordBuilder[T]): T = {
+      schemaBuilder: RecordBuilder[T],
+      recordNamespace: String): T = {
     val fieldsAssembler: FieldAssembler[T] = schemaBuilder.fields()
     structType.fields.foreach { field =>
       val newField = fieldsAssembler.name(field.name).`type`()
 
       if (field.nullable) {
-        convertFieldTypeToAvro(field.dataType, newField.nullable(), field.name).noDefault
+        convertFieldTypeToAvro(field.dataType, newField.nullable(), field.name, recordNamespace).noDefault
       } else {
-        convertFieldTypeToAvro(field.dataType, newField, field.name).noDefault
+        convertFieldTypeToAvro(field.dataType, newField, field.name, recordNamespace).noDefault
       }
     }
     fieldsAssembler.endRecord()
@@ -115,7 +116,8 @@ private object SchemaConverters {
   private def convertTypeToAvro[T](
       dataType: DataType,
       schemaBuilder: BaseTypeBuilder[T],
-      structName: String): T = {
+      structName: String,
+      recordNamespace: String): T = {
     dataType match {
       case ByteType => schemaBuilder.intType()
       case ShortType => schemaBuilder.intType()
@@ -131,16 +133,16 @@ private object SchemaConverters {
 
       case ArrayType(elementType, _) =>
         val builder = getSchemaBuilder(dataType.asInstanceOf[ArrayType].containsNull)
-        val elementSchema = convertTypeToAvro(elementType, builder, structName)
+        val elementSchema = convertTypeToAvro(elementType, builder, structName, recordNamespace)
         schemaBuilder.array().items(elementSchema)
 
       case MapType(StringType, valueType, _) =>
         val builder = getSchemaBuilder(dataType.asInstanceOf[MapType].valueContainsNull)
-        val valueSchema = convertTypeToAvro(valueType, builder, structName)
+        val valueSchema = convertTypeToAvro(valueType, builder, structName, recordNamespace)
         schemaBuilder.map().values(valueSchema)
 
       case structType: StructType =>
-        convertStructToAvro(structType, schemaBuilder.record(structName))
+        convertStructToAvro(structType, schemaBuilder.record(structName).namespace(recordNamespace), recordNamespace)
 
       case other => throw new IllegalArgumentException(s"Unexpected type $dataType.")
     }
@@ -154,7 +156,8 @@ private object SchemaConverters {
   private def convertFieldTypeToAvro[T](
       dataType: DataType,
       newFieldBuilder: BaseFieldTypeBuilder[T],
-      structName: String): FieldDefault[T, _] = {
+      structName: String,
+      recordNamespace: String): FieldDefault[T, _] = {
     dataType match {
       case ByteType => newFieldBuilder.intType()
       case ShortType => newFieldBuilder.intType()
@@ -170,16 +173,16 @@ private object SchemaConverters {
 
       case ArrayType(elementType, _) =>
         val builder = getSchemaBuilder(dataType.asInstanceOf[ArrayType].containsNull)
-        val elementSchema = convertTypeToAvro(elementType, builder, structName)
+        val elementSchema = convertTypeToAvro(elementType, builder, structName, recordNamespace)
         newFieldBuilder.array().items(elementSchema)
 
       case MapType(StringType, valueType, _) =>
         val builder = getSchemaBuilder(dataType.asInstanceOf[MapType].valueContainsNull)
-        val valueSchema = convertTypeToAvro(valueType, builder, structName)
+        val valueSchema = convertTypeToAvro(valueType, builder, structName, recordNamespace)
         newFieldBuilder.map().values(valueSchema)
 
       case structType: StructType =>
-        convertStructToAvro(structType, newFieldBuilder.record(structName))
+        convertStructToAvro(structType, newFieldBuilder.record(structName).namespace(recordNamespace), recordNamespace)
 
       case other => throw new IllegalArgumentException(s"Unexpected type $dataType.")
     }

--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -101,9 +101,11 @@ private object SchemaConverters {
       val newField = fieldsAssembler.name(field.name).`type`()
 
       if (field.nullable) {
-        convertFieldTypeToAvro(field.dataType, newField.nullable(), field.name, recordNamespace).noDefault
+        convertFieldTypeToAvro(field.dataType, newField.nullable(), field.name, recordNamespace)
+          .noDefault
       } else {
-        convertFieldTypeToAvro(field.dataType, newField, field.name, recordNamespace).noDefault
+        convertFieldTypeToAvro(field.dataType, newField, field.name, recordNamespace)
+          .noDefault
       }
     }
     fieldsAssembler.endRecord()
@@ -142,7 +144,10 @@ private object SchemaConverters {
         schemaBuilder.map().values(valueSchema)
 
       case structType: StructType =>
-        convertStructToAvro(structType, schemaBuilder.record(structName).namespace(recordNamespace), recordNamespace)
+        convertStructToAvro(
+          structType,
+          schemaBuilder.record(structName).namespace(recordNamespace),
+          recordNamespace)
 
       case other => throw new IllegalArgumentException(s"Unexpected type $dataType.")
     }
@@ -182,7 +187,10 @@ private object SchemaConverters {
         newFieldBuilder.map().values(valueSchema)
 
       case structType: StructType =>
-        convertStructToAvro(structType, newFieldBuilder.record(structName).namespace(recordNamespace), recordNamespace)
+        convertStructToAvro(
+          structType,
+          newFieldBuilder.record(structName).namespace(recordNamespace),
+          recordNamespace)
 
       case other => throw new IllegalArgumentException(s"Unexpected type $dataType.")
     }

--- a/src/main/scala/com/databricks/spark/avro/package.scala
+++ b/src/main/scala/com/databricks/spark/avro/package.scala
@@ -32,8 +32,8 @@ package object avro {
    */
   implicit class AvroDataFrame(dataFrame: DataFrame) {
     def saveAsAvroFile(
-       path: String,
-       recordName: String = "topLevelRecord",
-       recordNamespace: String = ""): Unit = AvroSaver.save(dataFrame, path)
+        path: String,
+        parameters: Map[String, String] = AvroSaver.defaultParameters): Unit =
+      AvroSaver.save(dataFrame, path, parameters)
   }
 }

--- a/src/main/scala/com/databricks/spark/avro/package.scala
+++ b/src/main/scala/com/databricks/spark/avro/package.scala
@@ -31,6 +31,9 @@ package object avro {
    * Adds a method, `saveAsAvroFile`, to DataFrame that allows you to save it as avro file.
    */
   implicit class AvroDataFrame(dataFrame: DataFrame) {
-    def saveAsAvroFile(path: String, recordName: String = "topLevelRecord", recordNamespace: String = ""): Unit = AvroSaver.save(dataFrame, path)
+    def saveAsAvroFile(
+       path: String,
+       recordName: String = "topLevelRecord",
+       recordNamespace: String = ""): Unit = AvroSaver.save(dataFrame, path)
   }
 }

--- a/src/main/scala/com/databricks/spark/avro/package.scala
+++ b/src/main/scala/com/databricks/spark/avro/package.scala
@@ -31,6 +31,6 @@ package object avro {
    * Adds a method, `saveAsAvroFile`, to DataFrame that allows you to save it as avro file.
    */
   implicit class AvroDataFrame(dataFrame: DataFrame) {
-    def saveAsAvroFile(path: String): Unit = AvroSaver.save(dataFrame, path)
+    def saveAsAvroFile(path: String, recordName: String = "topLevelRecord", recordNamespace: String = ""): Unit = AvroSaver.save(dataFrame, path)
   }
 }

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -58,9 +58,7 @@ private[avro] object TestUtils {
 
     assert(originalEntries.size == newEntries.size)
 
-    val origEntrySet = new Array[HashSet[Any]](originalEntries(0).size)
-    for (i <- 0 until originalEntries(0).size) { origEntrySet(i) = new HashSet[Any]() }
-
+    val origEntrySet = Array.fill(originalEntries(0).size)(new HashSet[Any]())
     for (origEntry <- originalEntries) {
       var idx = 0
       for (origElement <- origEntry.toSeq) {

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -38,9 +38,8 @@ import TestSQLContext._
 private[avro] object TestUtils {
 
   /**
-   * This function deletes a file or a directory with everything that's in it. This function is
-   * copied from Spark with minor modifications made to it. See original source at:
-   * github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/util/Utils.scala
+   * This function checks that all records in a file match the original
+   * record.
    */
 
   def checkReloadMatchesSaved(testFile: String, avroDir: String) = {
@@ -60,7 +59,7 @@ private[avro] object TestUtils {
     assert(originalEntries.size == newEntries.size)
 
     val origEntrySet = new Array[HashSet[Any]](originalEntries(0).size)
-    for (i <- 0 until originalEntries(0).size) {origEntrySet(i) = new HashSet[Any]()}
+    for (i <- 0 until originalEntries(0).size) { origEntrySet(i) = new HashSet[Any]() }
 
     for (origEntry <- originalEntries) {
       var idx = 0
@@ -78,6 +77,12 @@ private[avro] object TestUtils {
       }
     }
   }
+
+  /**
+   * This function deletes a file or a directory with everything that's in it. This function is
+   * copied from Spark with minor modifications made to it. See original source at:
+   * github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/util/Utils.scala
+   */
 
   def deleteRecursively(file: File) {
     def listFilesSafely(file: File): Seq[File] = {
@@ -258,10 +263,11 @@ class AvroSuite extends FunSuite {
     // get the same values back.
     val name = "AvroTest"
     val namespace = "com.databricks.spark.avro"
+    val parameters = Map("recordName" -> name, "recordNamespace" -> namespace)
 
     val tempDir = Files.createTempDir()
     val avroDir = tempDir + "/namedAvro"
-    AvroSaver.save(TestSQLContext.avroFile(testFile), avroDir, name, namespace)
+    AvroSaver.save(TestSQLContext.avroFile(testFile), avroDir, parameters)
 
     TestUtils.checkReloadMatchesSaved(testFile, avroDir)
 
@@ -438,4 +444,5 @@ class AvroSuite extends FunSuite {
     val newDf = TestSQLContext.load(tempSaveDir, "com.databricks.spark.avro")
     assert(newDf.count == 8)
   }
+
 }

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -42,6 +42,43 @@ private[avro] object TestUtils {
    * copied from Spark with minor modifications made to it. See original source at:
    * github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/util/Utils.scala
    */
+
+  def checkReloadMatchesSaved(testFile: String, avroDir: String) = {
+
+    def convertToString(elem: Any): String = {
+      elem match {
+        case null => "NULL" // HashSets can't have null in them, so we use a string instead
+        case arrayBuf: ArrayBuffer[Any] => arrayBuf.toArray.deep.mkString(" ")
+        case arrayByte: Array[Byte] => arrayByte.deep.mkString(" ")
+        case other => other.toString
+      }
+    }
+
+    val originalEntries = TestSQLContext.avroFile(testFile).collect()
+    val newEntries = TestSQLContext.avroFile(avroDir).collect()
+
+    assert(originalEntries.size == newEntries.size)
+
+    val origEntrySet = new Array[HashSet[Any]](originalEntries(0).size)
+    for (i <- 0 until originalEntries(0).size) {origEntrySet(i) = new HashSet[Any]()}
+
+    for (origEntry <- originalEntries) {
+      var idx = 0
+      for (origElement <- origEntry.toSeq) {
+        origEntrySet(idx) += convertToString(origElement)
+        idx += 1
+      }
+    }
+
+    for (newEntry <- newEntries) {
+      var idx = 0
+      for (newElement <- newEntry.toSeq) {
+        assert(origEntrySet(idx).contains(convertToString(newElement)))
+        idx += 1
+      }
+    }
+  }
+
   def deleteRecursively(file: File) {
     def listFilesSafely(file: File): Seq[File] = {
       if (file.exists()) {
@@ -208,42 +245,31 @@ class AvroSuite extends FunSuite {
     // Note that test.avro includes a variety of types, some of which are nullable. We expect to
     // get the same values back.
 
-    def convertToString(elem: Any): String = {
-      elem match {
-        case null => "NULL" // HashSets can't have null in them, so we use a string instead
-        case arrayBuf: ArrayBuffer[Any] => arrayBuf.toArray.deep.mkString(" ")
-        case arrayByte: Array[Byte] => arrayByte.deep.mkString(" ")
-        case other => other.toString
-      }
-    }
-
     val tempDir = Files.createTempDir()
     val avroDir = tempDir + "/avro"
     AvroSaver.save(TestSQLContext.avroFile(testFile), avroDir)
 
-    val originalEntries = TestSQLContext.avroFile(testFile).collect()
-    val newEntries = TestSQLContext.avroFile(avroDir).collect()
+    TestUtils.checkReloadMatchesSaved(testFile, avroDir)
+    TestUtils.deleteRecursively(tempDir)
+  }
 
-    assert(originalEntries.size == newEntries.size)
+  test("conversion to avro and back with namespace") {
+    // Note that test.avro includes a variety of types, some of which are nullable. We expect to
+    // get the same values back.
+    val name = "AvroTest"
+    val namespace = "com.databricks.spark.avro"
 
-    val origEntrySet = new Array[HashSet[Any]](originalEntries(0).size)
-    for (i <- 0 until originalEntries(0).size) {origEntrySet(i) = new HashSet[Any]()}
+    val tempDir = Files.createTempDir()
+    val avroDir = tempDir + "/namedAvro"
+    AvroSaver.save(TestSQLContext.avroFile(testFile), avroDir, name, namespace)
 
-    for (origEntry <- originalEntries) {
-      var idx = 0
-      for (origElement <- origEntry.toSeq) {
-        origEntrySet(idx) += convertToString(origElement)
-        idx += 1
-      }
-    }
+    TestUtils.checkReloadMatchesSaved(testFile, avroDir)
 
-    for (newEntry <- newEntries) {
-      var idx = 0
-      for (newElement <- newEntry.toSeq) {
-        assert(origEntrySet(idx).contains(convertToString(newElement)))
-        idx += 1
-      }
-    }
+    // Look at raw file and make sure has namespace info
+    val rawSaved = TestSQLContext.sparkContext.textFile(avroDir)
+    val schema = rawSaved.first()
+    assert(schema.contains(name))
+    assert(schema.contains(namespace))
 
     TestUtils.deleteRecursively(tempDir)
   }


### PR DESCRIPTION
...be specified.

This allows records written with spark-avro to be read as SpecificRecords downstream.
Included default values for backwards compatibility.
Updated test coverage.
