### PR TITLE
Integrate code coverage metrics using codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,7 @@ jdk:
 sudo: false
 script:
   - sbt -jvm-opts travis/jvmopts.compile compile
-  - sbt -jvm-opts travis/jvmopts.test test
+  - sbt -jvm-opts travis/jvmopts.test coverage test
   - sbt -jvm-opts travis/jvmopts.test scalastyle
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A library for querying Avro data with [Spark SQL](http://spark.apache.org/docs/latest/sql-programming-guide.html) and saving Spark SQL as Avro.
 
 [![Build Status](https://travis-ci.org/databricks/spark-avro.svg?branch=master)](https://travis-ci.org/databricks/spark-avro)
+[![codecov.io](http://codecov.io/github/databricks/spark-avro/coverage.svg?branch=master)](http://codecov.io/github/databricks/spark-avro?branch=master)
 
 ## Requirements
 

--- a/build.sbt
+++ b/build.sbt
@@ -49,3 +49,8 @@ pomExtra := (
   </developers>)
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.1" % "test"
+
+ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting := {
+  if (scalaBinaryVersion.value == "2.10") false
+  else false
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -35,6 +35,8 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")
 
 addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.0")
 
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.1.0")
+
 libraryDependencies += "org.ow2.asm"  % "asm" % "5.0.3"
 
 libraryDependencies += "org.ow2.asm"  % "asm-commons" % "5.0.3"


### PR DESCRIPTION
This PR integrates code coverage into our build using Scoverage and http://codecov.io.

After this PR is merged, you should be able to view coverage metrics at https://codecov.io/github/databricks/spark-avro or in GitHub by using the Codecov browser plugin.
