### PR TITLE
small fix for test case that is not compatiable with Spark > 1.4.0

### DIFF
--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -285,7 +285,7 @@ class AvroSuite extends FunSuite {
       val cityRDD = sparkContext.parallelize(Seq(
         Row("San Francisco", 12, new Timestamp(666), null, arrayOfByte),
         Row("Palo Alto", null, new Timestamp(777), null, arrayOfByte),
-        Row("Munich", 8, new Timestamp(42), 3.14, arrayOfByte)))
+        Row("Munich", 8, new Timestamp(42), Decimal(3.14), arrayOfByte)))
       val cityDataFrame = TestSQLContext.createDataFrame(cityRDD, testSchema)
 
       val avroDir = tempDir + "/avro"


### PR DESCRIPTION
@marmbrus This is a quick fix for one of the test cases. It seems that versions of Spark greater than 1.4 will not convert this automatically, causing this to fail when I run it.