### PR TITLE
Added Partitioning to work with Avro

### DIFF
--- a/src/main/scala/com/databricks/spark/avro/AvroOutputWriter.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroOutputWriter.scala
@@ -16,10 +16,12 @@
 
 package com.databricks.spark.avro
 
+import java.io.{OutputStream, IOException}
 import java.nio.ByteBuffer
 import java.sql.Timestamp
 import java.util.HashMap
 
+import org.apache.hadoop.fs.Path
 import scala.collection.immutable.Map
 
 import org.apache.avro.generic.GenericData.Record
@@ -42,8 +44,26 @@ private[avro] class AvroOutputWriter(path: String,
 
   private lazy val converter = createConverterToAvro(schema, recordName, recordNamespace)
 
+  /**
+   * Overrides the couple of methods responsible for generating the output streams / files so
+   * that the data can be correctly partitioned
+   */
   private val recordWriter: RecordWriter[AvroKey[GenericRecord], NullWritable] =
-    new AvroKeyOutputFormat[GenericRecord]().getRecordWriter(context)
+    new AvroKeyOutputFormat[GenericRecord]() {
+
+      override def getDefaultWorkFile(context: TaskAttemptContext, extension: String): Path = {
+        val uniqueWriteJobId = context.getConfiguration.get("spark.sql.sources.writeJobUUID")
+        val split = context.getTaskAttemptID.getTaskID.getId
+        new Path(path, f"part-r-$split%05d-$uniqueWriteJobId$extension")
+      }
+
+      @throws(classOf[IOException])
+      override def getAvroFileOutputStream(c: TaskAttemptContext): OutputStream = {
+        val path = getDefaultWorkFile(context, ".avro")
+        path.getFileSystem(context.getConfiguration).create(path)
+      }
+
+    }.getRecordWriter(context)
 
   override def write(row: Row): Unit = {
     val key = new AvroKey(converter(row).asInstanceOf[GenericRecord])

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -285,7 +285,7 @@ class AvroSuite extends FunSuite {
       val cityRDD = sparkContext.parallelize(Seq(
         Row("San Francisco", 12, new Timestamp(666), null, arrayOfByte),
         Row("Palo Alto", null, new Timestamp(777), null, arrayOfByte),
-        Row("Munich", 8, new Timestamp(42), 3.14, arrayOfByte)))
+        Row("Munich", 8, new Timestamp(42), Decimal(3.14), arrayOfByte)))
       val cityDataFrame = TestSQLContext.createDataFrame(cityRDD, testSchema)
 
       val avroDir = tempDir + "/avro"

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -3,6 +3,7 @@ package com.databricks.spark.avro
 import java.io.File
 import java.nio.ByteBuffer
 import java.sql.Timestamp
+import java.util.UUID
 
 import scala.collection.JavaConversions._
 
@@ -20,6 +21,20 @@ import org.scalatest.FunSuite
 class AvroSuite extends FunSuite {
   val episodesFile = "src/test/resources/episodes.avro"
   val testFile = "src/test/resources/test.avro"
+
+  test("reading and writing partitioned data") {
+    TestUtils.withTempDir { dir =>
+      val df = TestSQLContext.read.avro(episodesFile)
+      val fields = List("title", "air_date", "doctor")
+      for (field <- fields) {
+        val outputDir = s"$dir/${UUID.randomUUID}"
+        df.write.partitionBy(field).avro(outputDir)
+        val input = TestSQLContext.read.avro(outputDir)
+        // makes sure that no fields got dropped
+        assert(input.select(field).collect().toSet === df.select(field).collect().toSet)
+      }
+    }
+  }
 
   test("request no fields") {
     val df = TestSQLContext.read.avro(episodesFile)

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -23,15 +23,15 @@ class AvroSuite extends FunSuite {
   val testFile = "src/test/resources/test.avro"
 
   test("reading and writing partitioned data") {
-    TestUtils.withTempDir { dir =>
       val df = TestSQLContext.read.avro(episodesFile)
       val fields = List("title", "air_date", "doctor")
       for (field <- fields) {
-        val outputDir = s"$dir/${UUID.randomUUID}"
-        df.write.partitionBy(field).avro(outputDir)
-        val input = TestSQLContext.read.avro(outputDir)
-        // makes sure that no fields got dropped
-        assert(input.select(field).collect().toSet === df.select(field).collect().toSet)
+        TestUtils.withTempDir { dir =>
+          val outputDir = s"$dir/${UUID.randomUUID}"
+          df.write.partitionBy(field).avro(outputDir)
+          val input = TestSQLContext.read.avro(outputDir)
+          // makes sure that no fields got dropped
+          assert(input.select(field).collect().toSet === df.select(field).collect().toSet)
       }
     }
   }


### PR DESCRIPTION
This library currently does not work with partitioning, it will fail silently due to what I expect is multiple writers trying to write to the same file. 

This PR modifies the record writer to use unique file names so this does not happen. 