### PR TITLE
Added differentiation of nested records with the same name

### DIFF
--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -235,8 +235,8 @@ private object SchemaConverters {
       case structType: StructType =>
         convertStructToAvro(
           structType,
-          schemaBuilder.record(recordNamespace+"."+structName),
-          recordNamespace+"."+structName)
+          schemaBuilder.record(recordNamespace + "." + structName),
+          recordNamespace + "." + structName)
 
       case other => throw new IllegalArgumentException(s"Unexpected type $dataType.")
     }
@@ -278,8 +278,8 @@ private object SchemaConverters {
       case structType: StructType =>
         convertStructToAvro(
           structType,
-          newFieldBuilder.record(recordNamespace+"."+structName),
-          recordNamespace+"."+structName)
+          newFieldBuilder.record(recordNamespace + "." + structName),
+          recordNamespace + "." + structName)
 
       case other => throw new IllegalArgumentException(s"Unexpected type $dataType.")
     }

--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -235,8 +235,8 @@ private object SchemaConverters {
       case structType: StructType =>
         convertStructToAvro(
           structType,
-          schemaBuilder.record(structName).namespace(recordNamespace),
-          recordNamespace)
+          schemaBuilder.record(recordNamespace+"."+structName),
+          recordNamespace+"."+structName)
 
       case other => throw new IllegalArgumentException(s"Unexpected type $dataType.")
     }
@@ -278,8 +278,8 @@ private object SchemaConverters {
       case structType: StructType =>
         convertStructToAvro(
           structType,
-          newFieldBuilder.record(structName).namespace(recordNamespace),
-          recordNamespace)
+          newFieldBuilder.record(recordNamespace+"."+structName),
+          recordNamespace+"."+structName)
 
       case other => throw new IllegalArgumentException(s"Unexpected type $dataType.")
     }


### PR DESCRIPTION
by adding to each record definition a namespace definition consisting of a
dot-separated concatenation of the enclosing records' names.

This fixes https://github.com/databricks/spark-avro/issues/54

The implementation adheres to the Avro name/namespace specification
at https://avro.apache.org/docs/1.7.7/spec.html#Names
and uses the fullname definition (as opposed to seperate name and
namespace definition) to preserve union type resolution.
