### PR TITLE
fix read multiple avro files at the same time

### DIFF
--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -27,6 +27,12 @@ class AvroSuite extends FunSuite {
     assert(TestSQLContext.sql("select count(*) from avro_table").collect().head === Row(8))
   }
 
+  test("read multiple files") {
+    val df = TestSQLContext.avroFile(Seq(episodesFile, episodesFile).mkString(","))
+    df.registerTempTable("multiple_avro_table")
+    assert(TestSQLContext.sql("select count(*) from multiple_avro_table").collect().head === Row(16))
+  }
+
   test("convert formats") {
     TestUtils.withTempDir { dir =>
       val df = TestSQLContext.read.avro(episodesFile)


### PR DESCRIPTION
Hi all, I find that the avroFile function in package.scala doesn't work although it has a deprecated annotation. If this is not the right place let me know and I will move it. Right here, I just fix avroFile function to let it read multiple Avro files at the same time. You can use either a Sequence of file names or file names separated by comma.
