### PR TITLE
Test against Spark 1.5.0-rc2 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,19 @@
 language: scala
-scala:
-  - 2.10.4
-jdk:
-  - openjdk7
-  - openjdk6
 sudo: false
 cache:
   directories:
     - $HOME/.ivy2
-env:
-  matrix:
-    - SPARK_VERSION="1.4.0"
-    - SPARK_VERSION="1.5.0-rc1"
+matrix:
+  include:
+    - jdk: openjdk6
+      scala: 2.10.4
+      env: SPARK_VERSION="1.4.0"
+    - jdk: openjdk7
+      scala: 2.10.4
+      env: SPARK_VERSION="1.4.0"
+    - jdk: openjdk7
+      scala: 2.10.4
+      env: SPARK_VERSION="1.5.0-rc1"
 script:
   - sbt -jvm-opts travis/jvmopts.compile -Dspark.version=$SPARK_VERSION compile
   - sbt -jvm-opts travis/jvmopts.test -Dspark.version=$SPARK_VERSION coverage test

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ matrix:
       scala: 2.10.4
       env: TEST_SPARK_VERSION="1.5.0-rc2"
 script:
-  - sbt -jvm-opts travis/jvmopts.compile -Dspark.test.version=$TEST_SPARK_VERSION compile
-  - sbt -jvm-opts travis/jvmopts.test -Dspark.test.version=$TEST_SPARK_VERSION coverage test
-  - sbt -jvm-opts travis/jvmopts.test -Dspark.test.version=$TEST_SPARK_VERSION scalastyle
+  - sbt -Dspark.testVersion=$TEST_SPARK_VERSION coverage test
+  - sbt scalastyle
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,11 @@ matrix:
     - jdk: openjdk7
       scala: 2.10.4
       env: TEST_SPARK_VERSION="1.5.0-rc2"
+    - jdk: openjdk7
+      scala: 2.11.7
+      env: TEST_SPARK_VERSION="1.5.0-rc2"
 script:
-  - sbt -Dspark.testVersion=$TEST_SPARK_VERSION coverage test
-  - sbt scalastyle
+  - sbt -Dspark.testVersion=$TEST_SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test
+  - sbt ++$TRAVIS_SCALA_VERSION scalastyle
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ jdk:
   - openjdk7
   - openjdk6
 sudo: false
+cache:
+  directories:
+    - $HOME/.ivy2
 env:
   matrix:
     - SPARK_VERSION="1.4.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       env: SPARK_VERSION="1.4.0"
     - jdk: openjdk7
       scala: 2.10.4
-      env: SPARK_VERSION="1.5.0-rc1"
+      env: SPARK_VERSION="1.5.0-rc2"
 script:
   - sbt -jvm-opts travis/jvmopts.compile -Dspark.version=$SPARK_VERSION compile
   - sbt -jvm-opts travis/jvmopts.test -Dspark.version=$SPARK_VERSION coverage test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,13 @@ jdk:
   - openjdk7
   - openjdk6
 sudo: false
+env:
+  matrix:
+    - SPARK_VERSION="1.4.0"
+    - SPARK_VERSION="1.5.0-rc1"
 script:
-  - sbt -jvm-opts travis/jvmopts.compile compile
-  - sbt -jvm-opts travis/jvmopts.test coverage test
-  - sbt -jvm-opts travis/jvmopts.test scalastyle
+  - sbt -jvm-opts travis/jvmopts.compile -Dspark.version=$SPARK_VERSION compile
+  - sbt -jvm-opts travis/jvmopts.test -Dspark.version=$SPARK_VERSION coverage test
+  - sbt -jvm-opts travis/jvmopts.test -Dspark.version=$SPARK_VERSION scalastyle
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,16 @@ matrix:
   include:
     - jdk: openjdk6
       scala: 2.10.4
-      env: SPARK_VERSION="1.4.0"
+      env: TEST_SPARK_VERSION="1.4.1"
     - jdk: openjdk7
       scala: 2.10.4
-      env: SPARK_VERSION="1.4.0"
+      env: TEST_SPARK_VERSION="1.4.1"
     - jdk: openjdk7
       scala: 2.10.4
-      env: SPARK_VERSION="1.5.0-rc2"
+      env: TEST_SPARK_VERSION="1.5.0-rc2"
 script:
-  - sbt -jvm-opts travis/jvmopts.compile -Dspark.version=$SPARK_VERSION compile
-  - sbt -jvm-opts travis/jvmopts.test -Dspark.version=$SPARK_VERSION coverage test
-  - sbt -jvm-opts travis/jvmopts.test -Dspark.version=$SPARK_VERSION scalastyle
+  - sbt -jvm-opts travis/jvmopts.compile -Dspark.test.version=$TEST_SPARK_VERSION compile
+  - sbt -jvm-opts travis/jvmopts.test -Dspark.test.version=$TEST_SPARK_VERSION coverage test
+  - sbt -jvm-opts travis/jvmopts.test -Dspark.test.version=$TEST_SPARK_VERSION scalastyle
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/build.sbt
+++ b/build.sbt
@@ -72,3 +72,5 @@ ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting := {
 
 EclipseKeys.eclipseOutput := Some("target/eclipse")
 
+// Display full-length stacktraces from ScalaTest:
+testOptions in Test += Tests.Argument("-oF")

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ spName := "databricks/spark-avro"
 
 sparkVersion := sys.props.get("spark.version").getOrElse("1.4.0")
 
-resolvers += "Spark 1.5.0 RC1 Snapshot" at "https://repository.apache.org/content/repositories/orgapachespark-1137"
+resolvers += "Spark 1.5.0 RC2 Staging" at "https://repository.apache.org/content/repositories/orgapachespark-1141"
 
 spAppendScalaVersion := true
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,9 @@ crossScalaVersions := Seq("2.10.5", "2.11.7")
 
 spName := "databricks/spark-avro"
 
-sparkVersion := "1.4.0"
+sparkVersion := sys.props.get("spark.version").getOrElse("1.4.0")
+
+resolvers += "Spark 1.5.0 RC1 Snapshot" at "https://repository.apache.org/content/repositories/orgapachespark-1137"
 
 spAppendScalaVersion := true
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ sparkVersion := "1.4.1"
 
 val testSparkVersion = settingKey[String]("The version of Spark to test against.")
 
-testSparkVersion := sys.props.getOrElse("spark.test.version", sparkVersion.value)
+testSparkVersion := sys.props.getOrElse("spark.testVersion", sparkVersion.value)
 
 resolvers += "Spark 1.5.0 RC2 Staging" at "https://repository.apache.org/content/repositories/orgapachespark-1141"
 
@@ -22,12 +22,18 @@ spAppendScalaVersion := true
 
 spIncludeMaven := true
 
+spIgnoreProvided := true
+
 sparkComponents := Seq("sql")
 
 libraryDependencies ++= Seq(
   "org.apache.avro" % "avro" % "1.7.6" exclude("org.mortbay.jetty", "servlet-api"),
   "org.apache.avro" % "avro-mapred" % "1.7.6"  classifier "hadoop2"  exclude("org.mortbay.jetty", "servlet-api"),
   "org.scalatest" %% "scalatest" % "2.2.1" % "test",
+  "commons-io" % "commons-io" % "2.4" % "test"
+)
+
+libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % testSparkVersion.value % "test",
   "org.apache.spark" %% "spark-sql" % testSparkVersion.value % "test"
 )
@@ -68,13 +74,9 @@ pomExtra :=
     </developer>
   </developers>
 
-
-
-libraryDependencies += "commons-io" % "commons-io" % "2.4" % "test"
-
 ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting := {
   if (scalaBinaryVersion.value == "2.10") false
-  else false
+  else true
 }
 
 EclipseKeys.eclipseOutput := Some("target/eclipse")

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,11 @@ crossScalaVersions := Seq("2.10.5", "2.11.7")
 
 spName := "databricks/spark-avro"
 
-sparkVersion := sys.props.get("spark.version").getOrElse("1.4.0")
+sparkVersion := "1.4.1"
+
+val testSparkVersion = settingKey[String]("The version of Spark to test against.")
+
+testSparkVersion := sys.props.getOrElse("spark.test.version", sparkVersion.value)
 
 resolvers += "Spark 1.5.0 RC2 Staging" at "https://repository.apache.org/content/repositories/orgapachespark-1141"
 
@@ -23,7 +27,10 @@ sparkComponents := Seq("sql")
 libraryDependencies ++= Seq(
   "org.apache.avro" % "avro" % "1.7.6" exclude("org.mortbay.jetty", "servlet-api"),
   "org.apache.avro" % "avro-mapred" % "1.7.6"  classifier "hadoop2"  exclude("org.mortbay.jetty", "servlet-api"),
-  "org.scalatest" %% "scalatest" % "2.2.1" % "test")
+  "org.scalatest" %% "scalatest" % "2.2.1" % "test",
+  "org.apache.spark" %% "spark-core" % testSparkVersion.value % "test",
+  "org.apache.spark" %% "spark-sql" % testSparkVersion.value % "test"
+)
 
 publishMavenStyle := true
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=0.13.6
+sbt.version=0.13.9

--- a/src/test/scala/com/databricks/spark/avro/AvroReadBenchmark.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroReadBenchmark.scala
@@ -3,7 +3,8 @@ package com.databricks.spark.avro
 import java.io.File
 import java.util.concurrent.TimeUnit
 
-import org.apache.spark.sql.test.TestSQLContext
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.SQLContext
 
 
 /**
@@ -20,12 +21,14 @@ object AvroReadBenchmark {
         "is empty. First you should generate some files to run a benchmark with (see README)")
     }
 
-    TestSQLContext.read.avro(AvroFileGenerator.outputDir).count()
+    val sqlContext = new SQLContext(new SparkContext("local[2]", "AvroReadBenchmark"))
 
-   println("\n\n\nStaring benchmark test - creating DataFrame from benchmark avro files\n\n\n")
+    sqlContext.read.avro(AvroFileGenerator.outputDir).count()
+
+    println("\n\n\nStaring benchmark test - creating DataFrame from benchmark avro files\n\n\n")
 
     val startTime = System.nanoTime
-    TestSQLContext
+    sqlContext
       .read
       .avro(AvroFileGenerator.outputDir)
       .select("string")
@@ -35,6 +38,6 @@ object AvroReadBenchmark {
 
     println(s"\n\n\nFinished benchmark test - result was $executionTime seconds\n\n\n")
 
-    TestSQLContext.sparkContext.stop()  // Otherwise scary exception message appears
+    sqlContext.sparkContext.stop()  // Otherwise scary exception message appears
   }
 }

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -45,6 +45,7 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
         df.write.partitionBy(field).avro(outputDir)
         val input = sqlContext.read.avro(outputDir)
         // makes sure that no fields got dropped
+        assert(input.select(field).collect().map(_(0).asInstanceOf[String]).sorted === df.select(field).collect().map(_(0).asInstanceOf[String]).sorted)
         assert(input.select(field).collect().toSet === df.select(field).collect().toSet)
       }
     }

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -11,33 +11,47 @@ import org.apache.avro.Schema.{Type, Field}
 import org.apache.avro.file.DataFileWriter
 import org.apache.avro.generic.{GenericData, GenericRecord, GenericDatumWriter}
 import org.apache.commons.io.FileUtils
-import org.apache.spark.sql.Row
-import org.apache.spark.sql.test.TestSQLContext
-import org.apache.spark.sql.test.TestSQLContext._
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.{SQLContext, Row}
 import org.apache.spark.sql.types._
-import org.scalatest.FunSuite
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
-class AvroSuite extends FunSuite {
+class AvroSuite extends FunSuite with BeforeAndAfterAll {
   val episodesFile = "src/test/resources/episodes.avro"
   val testFile = "src/test/resources/test.avro"
 
+  private var sqlContext: SQLContext = _
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    sqlContext = new SQLContext(new SparkContext("local[2]", "AvroSuite"))
+  }
+
+  override protected def afterAll(): Unit = {
+    try {
+      sqlContext.sparkContext.stop()
+    } finally {
+      super.afterAll()
+    }
+  }
+
   test("request no fields") {
-    val df = TestSQLContext.read.avro(episodesFile)
+    val df = sqlContext.read.avro(episodesFile)
     df.registerTempTable("avro_table")
-    assert(TestSQLContext.sql("select count(*) from avro_table").collect().head === Row(8))
+    assert(sqlContext.sql("select count(*) from avro_table").collect().head === Row(8))
   }
 
   test("convert formats") {
     TestUtils.withTempDir { dir =>
-      val df = TestSQLContext.read.avro(episodesFile)
+      val df = sqlContext.read.avro(episodesFile)
       df.write.parquet(dir.getCanonicalPath)
-      assert(TestSQLContext.read.parquet(dir.getCanonicalPath).count() === df.count)
+      assert(sqlContext.read.parquet(dir.getCanonicalPath).count() === df.count)
     }
   }
 
   test("rearrange internal schema") {
     TestUtils.withTempDir { dir =>
-      val df = TestSQLContext.read.avro(episodesFile)
+      val df = sqlContext.read.avro(episodesFile)
       df.select("doctor", "title").write.avro(dir.getCanonicalPath)
     }
   }
@@ -56,7 +70,7 @@ class AvroSuite extends FunSuite {
       dataFileWriter.flush()
       dataFileWriter.close()
       intercept[SchemaConversionException] {
-        TestSQLContext.read.avro(s"$dir.avro")
+        sqlContext.read.avro(s"$dir.avro")
       }
     }
   }
@@ -81,7 +95,7 @@ class AvroSuite extends FunSuite {
       dataFileWriter.flush()
       dataFileWriter.close()
       intercept[SchemaConversionException] {
-        TestSQLContext.read.avro(s"$dir.avro")
+        sqlContext.read.avro(s"$dir.avro")
       }
     }
   }
@@ -94,14 +108,14 @@ class AvroSuite extends FunSuite {
         StructField("array", ArrayType(ShortType), true),
         StructField("map", MapType(StringType, StringType), true),
         StructField("struct", StructType(Seq(StructField("int", IntegerType, true))))))
-      val rdd = sparkContext.parallelize(Seq[Row](
+      val rdd = sqlContext.sparkContext.parallelize(Seq[Row](
         Row(null, new Timestamp(1), Array[Short](1,2,3), null, null),
         Row(null, null, null, null, null),
         Row(null, null, null, null, null),
         Row(null, null, null, null, null)))
-      val df = TestSQLContext.createDataFrame(rdd, schema)
+      val df = sqlContext.createDataFrame(rdd, schema)
       df.write.avro(dir.toString)
-      assert(TestSQLContext.read.avro(dir.toString).count == rdd.count)
+      assert(sqlContext.read.avro(dir.toString).count == rdd.count)
     }
   }
 
@@ -113,14 +127,14 @@ class AvroSuite extends FunSuite {
         StructField("byte", ByteType, true),
         StructField("boolean", BooleanType, true)
       ))
-      val rdd = sparkContext.parallelize(Seq(
+      val rdd = sqlContext.sparkContext.parallelize(Seq(
         Row(1f, 1.toShort, 1.toByte, true),
         Row(2f, 2.toShort, 2.toByte, true),
         Row(3f, 3.toShort, 3.toByte, true)
       ))
-      val df = TestSQLContext.createDataFrame(rdd, schema)
+      val df = sqlContext.createDataFrame(rdd, schema)
       df.write.avro(dir.toString)
-      assert(TestSQLContext.read.avro(dir.toString).count == rdd.count)
+      assert(sqlContext.read.avro(dir.toString).count == rdd.count)
     }
   }
 
@@ -144,16 +158,16 @@ class AvroSuite extends FunSuite {
         arrayOfByte(i) = i.toByte
       }
 
-      val rdd = sparkContext.parallelize(Seq(
+      val rdd = sqlContext.sparkContext.parallelize(Seq(
         Row(arrayOfByte, Array[Short](1,2,3,4), Array[Float](1f, 2f, 3f, 4f),
           Array[Boolean](true, false, true, false), Array[Long](1L, 2L), Array[Double](1.0, 2.0),
           Array[BigDecimal](BigDecimal.valueOf(3)), Array[Array[Byte]](arrayOfByte, arrayOfByte),
           Array[Timestamp](new Timestamp(0)),
           Array[Array[String]](Array[String]("CSH, tearing down the walls that divide us", "-jd")),
           Array[Row](Row("Bobby G. can't swim")))))
-      val df = TestSQLContext.createDataFrame(rdd, testSchema)
+      val df = sqlContext.createDataFrame(rdd, testSchema)
       df.write.avro(dir.toString)
-      assert(TestSQLContext.read.avro(dir.toString).count == rdd.count)
+      assert(sqlContext.read.avro(dir.toString).count == rdd.count)
     }
   }
 
@@ -166,13 +180,13 @@ class AvroSuite extends FunSuite {
       val snappyDir = s"$dir/snappy"
       val fakeDir = s"$dir/fake"
 
-      val df = TestSQLContext.read.avro(testFile)
-      TestSQLContext.setConf(AVRO_COMPRESSION_CODEC, "uncompressed")
+      val df = sqlContext.read.avro(testFile)
+      sqlContext.setConf(AVRO_COMPRESSION_CODEC, "uncompressed")
       df.write.avro(uncompressDir)
-      TestSQLContext.setConf(AVRO_COMPRESSION_CODEC, "deflate")
-      TestSQLContext.setConf(AVRO_DEFLATE_LEVEL, "9")
+      sqlContext.setConf(AVRO_COMPRESSION_CODEC, "deflate")
+      sqlContext.setConf(AVRO_DEFLATE_LEVEL, "9")
       df.write.avro(deflateDir)
-      TestSQLContext.setConf(AVRO_COMPRESSION_CODEC, "snappy")
+      sqlContext.setConf(AVRO_COMPRESSION_CODEC, "snappy")
       df.write.avro(snappyDir)
 
       val uncompressSize = FileUtils.sizeOfDirectory(new File(uncompressDir))
@@ -185,58 +199,58 @@ class AvroSuite extends FunSuite {
   }
 
   test("dsl test") {
-    val results = TestSQLContext.read.avro(episodesFile).select("title").collect()
+    val results = sqlContext.read.avro(episodesFile).select("title").collect()
     assert(results.length === 8)
   }
 
   test("support of various data types") {
     // This test uses data from test.avro. You can see the data and the schema of this file in
     // test.json and test.avsc
-    val all = TestSQLContext.read.avro(testFile).collect()
+    val all = sqlContext.read.avro(testFile).collect()
     assert(all.length == 3)
 
-    val str = TestSQLContext.read.avro(testFile).select("string").collect()
+    val str = sqlContext.read.avro(testFile).select("string").collect()
     assert(str.map(_(0)).toSet.contains("Terran is IMBA!"))
 
-    val simple_map = TestSQLContext.read.avro(testFile).select("simple_map").collect()
+    val simple_map = sqlContext.read.avro(testFile).select("simple_map").collect()
     assert(simple_map(0)(0).getClass.toString.contains("Map"))
     assert(simple_map.map(_(0).asInstanceOf[Map[String, Some[Int]]].size).toSet == Set(2, 0))
 
-    val union0 = TestSQLContext.read.avro(testFile).select("union_string_null").collect()
+    val union0 = sqlContext.read.avro(testFile).select("union_string_null").collect()
     assert(union0.map(_(0)).toSet == Set("abc", "123", null))
 
-    val union1 = TestSQLContext.read.avro(testFile).select("union_int_long_null").collect()
+    val union1 = sqlContext.read.avro(testFile).select("union_int_long_null").collect()
     assert(union1.map(_(0)).toSet == Set(66, 1, null))
 
-    val union2 = TestSQLContext.read.avro(testFile).select("union_float_double").collect()
+    val union2 = sqlContext.read.avro(testFile).select("union_float_double").collect()
     assert(union2.map(x => new java.lang.Double(x(0).toString)).exists(p => Math.abs(p - Math.PI) < 0.001))
 
-    val fixed = TestSQLContext.read.avro(testFile).select("fixed3").collect()
+    val fixed = sqlContext.read.avro(testFile).select("fixed3").collect()
     assert(fixed.map(_(0).asInstanceOf[Array[Byte]]).exists(p => p(1) == 3))
 
-    val enum = TestSQLContext.read.avro(testFile).select("enum").collect()
+    val enum = sqlContext.read.avro(testFile).select("enum").collect()
     assert(enum.map(_(0)).toSet == Set("SPADES", "CLUBS", "DIAMONDS"))
 
-    val record = TestSQLContext.read.avro(testFile).select("record").collect()
+    val record = sqlContext.read.avro(testFile).select("record").collect()
     assert(record(0)(0).getClass.toString.contains("Row"))
     assert(record.map(_(0).asInstanceOf[Row](0)).contains("TEST_STR123"))
 
-    val array_of_boolean = TestSQLContext.read.avro(testFile).select("array_of_boolean").collect()
+    val array_of_boolean = sqlContext.read.avro(testFile).select("array_of_boolean").collect()
     assert(array_of_boolean.map(_(0).asInstanceOf[Seq[Boolean]].size).toSet == Set(3, 1, 0))
 
-    val bytes = TestSQLContext.read.avro(testFile).select("bytes").collect()
+    val bytes = sqlContext.read.avro(testFile).select("bytes").collect()
     assert(bytes.map(_(0).asInstanceOf[Array[Byte]].length).toSet == Set(3, 1, 0))
   }
 
   test("sql test") {
-    sql(
+    sqlContext.sql(
       s"""
          |CREATE TEMPORARY TABLE avroTable
          |USING com.databricks.spark.avro
          |OPTIONS (path "$episodesFile")
       """.stripMargin.replaceAll("\n", " "))
 
-    assert(sql("SELECT * FROM avroTable").collect().length === 8)
+    assert(sqlContext.sql("SELECT * FROM avroTable").collect().length === 8)
   }
 
   test("conversion to avro and back") {
@@ -244,8 +258,8 @@ class AvroSuite extends FunSuite {
     // get the same values back.
     TestUtils.withTempDir { dir =>
       val avroDir = s"$dir/avro"
-      TestSQLContext.read.avro(testFile).write.avro(avroDir)
-      TestUtils.checkReloadMatchesSaved(testFile, avroDir)
+      sqlContext.read.avro(testFile).write.avro(avroDir)
+      TestUtils.checkReloadMatchesSaved(sqlContext, testFile, avroDir)
     }
   }
 
@@ -258,11 +272,11 @@ class AvroSuite extends FunSuite {
       val parameters = Map("recordName" -> name, "recordNamespace" -> namespace)
 
       val avroDir = tempDir + "/namedAvro"
-      TestSQLContext.read.avro(testFile).write.options(parameters).avro(avroDir)
-      TestUtils.checkReloadMatchesSaved(testFile, avroDir)
+      sqlContext.read.avro(testFile).write.options(parameters).avro(avroDir)
+      TestUtils.checkReloadMatchesSaved(sqlContext, testFile, avroDir)
 
       // Look at raw file and make sure has namespace info
-      val rawSaved = TestSQLContext.sparkContext.textFile(avroDir)
+      val rawSaved = sqlContext.sparkContext.textFile(avroDir)
       val schema = rawSaved.collect().mkString("")
       assert(schema.contains(name))
       assert(schema.contains(namespace))
@@ -282,29 +296,29 @@ class AvroSuite extends FunSuite {
       for (i <- arrayOfByte.indices) {
         arrayOfByte(i) = i.toByte
       }
-      val cityRDD = sparkContext.parallelize(Seq(
+      val cityRDD = sqlContext.sparkContext.parallelize(Seq(
         Row("San Francisco", 12, new Timestamp(666), null, arrayOfByte),
         Row("Palo Alto", null, new Timestamp(777), null, arrayOfByte),
         Row("Munich", 8, new Timestamp(42), 3.14, arrayOfByte)))
-      val cityDataFrame = TestSQLContext.createDataFrame(cityRDD, testSchema)
+      val cityDataFrame = sqlContext.createDataFrame(cityRDD, testSchema)
 
       val avroDir = tempDir + "/avro"
       cityDataFrame.write.avro(avroDir)
-      assert(TestSQLContext.read.avro(avroDir).collect().length == 3)
+      assert(sqlContext.read.avro(avroDir).collect().length == 3)
 
       // TimesStamps are converted to longs
-      val times = TestSQLContext.read.avro(avroDir).select("Time").collect()
+      val times = sqlContext.read.avro(avroDir).select("Time").collect()
       assert(times.map(_(0)).toSet == Set(666, 777, 42))
 
       // DecimalType should be converted to string
-      val decimals = TestSQLContext.read.avro(avroDir).select("Decimal").collect()
+      val decimals = sqlContext.read.avro(avroDir).select("Decimal").collect()
       assert(decimals.map(_(0)).contains("3.14"))
 
       // There should be a null entry
-      val length = TestSQLContext.read.avro(avroDir).select("Length").collect()
+      val length = sqlContext.read.avro(avroDir).select("Length").collect()
       assert(length.map(_(0)).contains(null))
 
-      val binary = TestSQLContext.read.avro(avroDir).select("Binary").collect()
+      val binary = sqlContext.read.avro(avroDir).select("Binary").collect()
       for (i <- arrayOfByte.indices) {
         assert(binary(1)(0).asInstanceOf[Array[Byte]](i) == arrayOfByte(i))
       }
@@ -312,10 +326,10 @@ class AvroSuite extends FunSuite {
   }
 
   test("support of globbed paths") {
-    val e1 = TestSQLContext.read.avro("*/test/resources/episodes.avro").collect()
+    val e1 = sqlContext.read.avro("*/test/resources/episodes.avro").collect()
     assert(e1.length == 8)
 
-    val e2 = TestSQLContext.read.avro("src/*/*/episodes.avro").collect()
+    val e2 = sqlContext.read.avro("src/*/*/episodes.avro").collect()
     assert(e2.length == 8)
   }
 
@@ -323,23 +337,23 @@ class AvroSuite extends FunSuite {
 
     // Directory given has no avro files
     intercept[AvroRelationException] {
-      TestUtils.withTempDir(dir => TestSQLContext.read.avro(dir.getCanonicalPath))
+      TestUtils.withTempDir(dir => sqlContext.read.avro(dir.getCanonicalPath))
     }
 
     intercept[AvroRelationException] {
-      TestSQLContext.read.avro("very/invalid/path/123.avro")
+      sqlContext.read.avro("very/invalid/path/123.avro")
     }
 
     // In case of globbed path that can't be matched to anything, another exception is thrown (and
     // exception message is helpful)
     intercept[AvroRelationException] {
-      TestSQLContext.read.avro("*/*/*/*/*/*/*/something.avro")
+      sqlContext.read.avro("*/*/*/*/*/*/*/something.avro")
     }
 
     intercept[NoAvroFilesException] {
       TestUtils.withTempDir { dir =>
         FileUtils.touch(new File(dir, "test"))
-        TestSQLContext.read.avro(dir.toString)
+        sqlContext.read.avro(dir.toString)
       }
     }
 
@@ -350,41 +364,41 @@ class AvroSuite extends FunSuite {
       val tempEmptyDir = s"$tempDir/sqlOverwrite"
       // Create a temp directory for table that will be overwritten
       new File(tempEmptyDir).mkdirs()
-      sql(
+      sqlContext.sql(
         s"""
            |CREATE TEMPORARY TABLE episodes
            |USING com.databricks.spark.avro
            |OPTIONS (path "$episodesFile")
         """.stripMargin.replaceAll("\n", " "))
-      sql(s"""
+      sqlContext.sql(s"""
              |CREATE TEMPORARY TABLE episodesEmpty
              |(name string, air_date string, doctor int)
              |USING com.databricks.spark.avro
              |OPTIONS (path "$tempEmptyDir")
         """.stripMargin.replaceAll("\n", " "))
 
-      assert(sql("SELECT * FROM episodes").collect().length === 8)
-      assert(sql("SELECT * FROM episodesEmpty").collect().isEmpty)
+      assert(sqlContext.sql("SELECT * FROM episodes").collect().length === 8)
+      assert(sqlContext.sql("SELECT * FROM episodesEmpty").collect().isEmpty)
 
-      sql(
+      sqlContext.sql(
         s"""
            |INSERT OVERWRITE TABLE episodesEmpty
            |SELECT * FROM episodes
         """.stripMargin.replaceAll("\n", " "))
-      assert(sql("SELECT * FROM episodesEmpty").collect().length == 8)
+      assert(sqlContext.sql("SELECT * FROM episodesEmpty").collect().length == 8)
     }
   }
 
   test("test save and load") {
     // Test if load works as expected
     TestUtils.withTempDir { tempDir =>
-      val df = TestSQLContext.read.avro(episodesFile)
+      val df = sqlContext.read.avro(episodesFile)
       assert(df.count == 8)
 
       val tempSaveDir = s"$tempDir/save/"
 
       df.write.avro(tempSaveDir)
-      val newDf = TestSQLContext.read.avro(tempSaveDir)
+      val newDf = sqlContext.read.avro(tempSaveDir)
       assert(newDf.count == 8)
     }
   }

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -147,7 +147,7 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
         StructField("bool_array", ArrayType(BooleanType), true),
         StructField("long_array", ArrayType(LongType), true),
         StructField("double_array", ArrayType(DoubleType), true),
-        StructField("decimal_array", ArrayType(DecimalType(5, 5)), true),
+        StructField("decimal_array", ArrayType(DecimalType(10, 0)), true),
         StructField("bin_array", ArrayType(BinaryType), true),
         StructField("timestamp_array", ArrayType(TimestampType), true),
         StructField("array_array", ArrayType(ArrayType(StringType), true), true),

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -44,9 +44,10 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
         val outputDir = s"$dir/${UUID.randomUUID}"
         df.write.partitionBy(field).avro(outputDir)
         val input = sqlContext.read.avro(outputDir)
-        // makes sure that no fields got dropped
-        assert(input.select(field).collect().map(_(0).asInstanceOf[String]).sorted === df.select(field).collect().map(_(0).asInstanceOf[String]).sorted)
-        assert(input.select(field).collect().toSet === df.select(field).collect().toSet)
+        // makes sure that no fields got dropped.
+        // We convert Rows to Seqs in order to work around SPARK-10325
+        assert(input.select(field).collect().map(_.toSeq).toSet ===
+          df.select(field).collect().map(_.toSeq).toSet)
       }
     }
   }

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -289,7 +289,7 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
         StructField("Name", StringType, false),
         StructField("Length", IntegerType, true),
         StructField("Time", TimestampType, false),
-        StructField("Decimal", DecimalType(10, 10), true),
+        StructField("Decimal", DecimalType(10, 2), true),
         StructField("Binary", BinaryType, false)))
 
       val arrayOfByte = new Array[Byte](4)
@@ -299,7 +299,7 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
       val cityRDD = sqlContext.sparkContext.parallelize(Seq(
         Row("San Francisco", 12, new Timestamp(666), null, arrayOfByte),
         Row("Palo Alto", null, new Timestamp(777), null, arrayOfByte),
-        Row("Munich", 8, new Timestamp(42), 3.14, arrayOfByte)))
+        Row("Munich", 8, new Timestamp(42), BigDecimal.valueOf(3.14), arrayOfByte)))
       val cityDataFrame = sqlContext.createDataFrame(cityRDD, testSchema)
 
       val avroDir = tempDir + "/avro"

--- a/src/test/scala/com/databricks/spark/avro/TestUtils.scala
+++ b/src/test/scala/com/databricks/spark/avro/TestUtils.scala
@@ -25,7 +25,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 
 import com.google.common.io.Files
-import org.apache.spark.sql.test.TestSQLContext
+import org.apache.spark.sql.SQLContext
 
 private[avro] object TestUtils {
 
@@ -33,7 +33,7 @@ private[avro] object TestUtils {
    * This function checks that all records in a file match the original
    * record.
    */
-  def checkReloadMatchesSaved(testFile: String, avroDir: String) = {
+  def checkReloadMatchesSaved(sqlContext: SQLContext, testFile: String, avroDir: String) = {
 
     def convertToString(elem: Any): String = {
       elem match {
@@ -44,8 +44,8 @@ private[avro] object TestUtils {
       }
     }
 
-    val originalEntries = TestSQLContext.read.avro(testFile).collect()
-    val newEntries = TestSQLContext.read.avro(avroDir).collect()
+    val originalEntries = sqlContext.read.avro(testFile).collect()
+    val newEntries = sqlContext.read.avro(avroDir).collect()
 
     assert(originalEntries.length == newEntries.length)
 


### PR DESCRIPTION
This PR adds Spark 1.5.0-rc2 to our Travis build matrix.  I removed the use of TestSQLContext since that class has been removed in Spark 1.5.