### PR TITLE
Minimize binary exception surface

### DIFF
--- a/src/main/scala/com/databricks/spark/avro/AvroOutputWriter.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroOutputWriter.scala
@@ -36,7 +36,8 @@ import org.apache.spark.sql.sources.OutputWriter
 import org.apache.spark.sql.types._
 
 // NOTE: This class is instantiated and used on executor side only, no need to be serializable.
-private[avro] class AvroOutputWriter(path: String,
+private[avro] class AvroOutputWriter(
+    path: String,
     context: TaskAttemptContext,
     schema: StructType,
     recordName: String,

--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -28,7 +28,6 @@ import org.apache.avro.Schema.Type._
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 
-
 /**
  * This object contains method that are used to convert sparkSQL schemas to avro schemas and vice
  * versa.
@@ -86,11 +85,11 @@ private object SchemaConverters {
             SchemaType(LongType, nullable = false)
           case Seq(t1, t2) if Set(t1, t2) == Set(FLOAT, DOUBLE) =>
             SchemaType(DoubleType, nullable = false)
-          case other => throw new SchemaConversionException(
+          case other => throw new UnsupportedOperationException(
             s"This mix of union types is not supported (see README): $other")
         }
 
-      case other => throw new SchemaConversionException(s"Unsupported type $other")
+      case other => throw new UnsupportedOperationException(s"Unsupported type $other")
     }
   }
 
@@ -193,10 +192,10 @@ private object SchemaConverters {
                 case null => null
               }
             }
-          case other => throw new SchemaConversionException(
+          case other => throw new UnsupportedOperationException(
             s"This mix of union types is not supported (see README): $other")
         }
-      case other => throw new SchemaConversionException(s"invalid avro type: $other")
+      case other => throw new UnsupportedOperationException(s"invalid avro type: $other")
     }
   }
 
@@ -281,7 +280,7 @@ private object SchemaConverters {
           newFieldBuilder.record(structName).namespace(recordNamespace),
           recordNamespace)
 
-      case other => throw new IllegalArgumentException(s"Unexpected type $dataType.")
+      case other => throw new UnsupportedOperationException(s"Unexpected type $dataType.")
     }
   }
 

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -1,6 +1,6 @@
 package com.databricks.spark.avro
 
-import java.io.File
+import java.io.{FileNotFoundException, File}
 import java.nio.ByteBuffer
 import java.sql.Timestamp
 import java.util.UUID
@@ -70,7 +70,7 @@ class AvroSuite extends FunSuite {
       dataFileWriter.append(avroRec)
       dataFileWriter.flush()
       dataFileWriter.close()
-      intercept[SchemaConversionException] {
+      intercept[UnsupportedOperationException] {
         TestSQLContext.read.avro(s"$dir.avro")
       }
     }
@@ -95,7 +95,7 @@ class AvroSuite extends FunSuite {
       dataFileWriter.append(avroRec)
       dataFileWriter.flush()
       dataFileWriter.close()
-      intercept[SchemaConversionException] {
+      intercept[UnsupportedOperationException] {
         TestSQLContext.read.avro(s"$dir.avro")
       }
     }
@@ -337,21 +337,21 @@ class AvroSuite extends FunSuite {
   test("reading from invalid path throws exception") {
 
     // Directory given has no avro files
-    intercept[AvroRelationException] {
+    intercept[FileNotFoundException] {
       TestUtils.withTempDir(dir => TestSQLContext.read.avro(dir.getCanonicalPath))
     }
 
-    intercept[AvroRelationException] {
+    intercept[FileNotFoundException] {
       TestSQLContext.read.avro("very/invalid/path/123.avro")
     }
 
     // In case of globbed path that can't be matched to anything, another exception is thrown (and
     // exception message is helpful)
-    intercept[AvroRelationException] {
+    intercept[FileNotFoundException] {
       TestSQLContext.read.avro("*/*/*/*/*/*/*/something.avro")
     }
 
-    intercept[NoAvroFilesException] {
+    intercept[FileNotFoundException] {
       TestUtils.withTempDir { dir =>
         FileUtils.touch(new File(dir, "test"))
         TestSQLContext.read.avro(dir.toString)


### PR DESCRIPTION
In order to ease binary compatibility down the road, I've replaced a bunch of Avro specific exceptions with appropriate java equivalents.  In the process I changed some pretty dense functional code that was running in the critical path, to a more explicit imperative version.