### PR TITLE
Allow a single published artifact to work with multiple Hadoop versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,26 +11,26 @@ matrix:
     # Spark 1.4.1 and Scala 2.10
     - jdk: openjdk6
       scala: 2.10.4
-      env: HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.4.1"
+      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.4.1"
     - jdk: openjdk7
       scala: 2.10.4
-      env: HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.4.1"
+      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.4.1"
     # Spark 1.5.0 and Scala 2.10
     - jdk: openjdk7
       scala: 2.10.4
-      env: HADOOP_VERSION="1.0.4" SPARK_VERSION="1.5.0-rc2"
+      env: TEST_HADOOP_VERSION="1.0.4" TEST_SPARK_VERSION="1.5.0-rc2"
     - jdk: openjdk7
       scala: 2.10.4
-      env: HADOOP_VERSION="1.2.1" SPARK_VERSION="1.5.0-rc2"
+      env: TEST_HADOOP_VERSION="1.2.1" TEST_SPARK_VERSION="1.5.0-rc2"
     - jdk: openjdk7
       scala: 2.10.4
-      env: HADOOP_VERSION="2.2.0" SPARK_VERSION="1.5.0-rc2"
+      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.5.0-rc2"
     # Spark 1.5.0 and Scala 2.11
     - jdk: openjdk7
       scala: 2.11.7
       env: TEST_SPARK_VERSION="1.5.0-rc2"
 script:
-  - sbt -Dhadoop.testVersion=$HADOOP_VERSION -Dspark.testVersion=$TEST_SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test
+  - sbt -Dhadoop.testVersion=$TEST_HADOOP_VERSION -Dspark.testVersion=$TEST_SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test
   - sbt ++$TRAVIS_SCALA_VERSION scalastyle
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,13 @@ matrix:
       scala: 2.10.4
       env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.4.1"
     # Spark 1.5.0 and Scala 2.10
-    - jdk: openjdk7
-      scala: 2.10.4
-      env: TEST_HADOOP_VERSION="1.0.4" TEST_SPARK_VERSION="1.5.0-rc2"
-    - jdk: openjdk7
-      scala: 2.10.4
-      env: TEST_HADOOP_VERSION="1.2.1" TEST_SPARK_VERSION="1.5.0-rc2"
+    # These two cases will fail in Travis until SPARK-10330 is fixed.
+    # - jdk: openjdk7
+    #   scala: 2.10.4
+    #   env: TEST_HADOOP_VERSION="1.0.4" TEST_SPARK_VERSION="1.5.0-rc2"
+    # - jdk: openjdk7
+    #   scala: 2.10.4
+    #   env: TEST_HADOOP_VERSION="1.2.1" TEST_SPARK_VERSION="1.5.0-rc2"
     - jdk: openjdk7
       scala: 2.10.4
       env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.5.0-rc2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
     # Spark 1.5.0 and Scala 2.11
     - jdk: openjdk7
       scala: 2.11.7
-      env: TEST_SPARK_VERSION="1.5.0-rc2"
+      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.5.0-rc2"
 script:
   - sbt -Dhadoop.testVersion=$TEST_HADOOP_VERSION -Dspark.testVersion=$TEST_SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test
   - sbt ++$TRAVIS_SCALA_VERSION scalastyle

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,32 @@ cache:
     - $HOME/.ivy2
 matrix:
   include:
+    # We only test Spark 1.4.1 with Hadooop 2.2.0 because
+    # https://github.com/apache/spark/pull/6599 is not present in 1.4.1,
+    # so the published Spark Maven artifacts will not work with Hadoop 1.x.
+    # Spark 1.4.1 and Scala 2.10
     - jdk: openjdk6
       scala: 2.10.4
-      env: TEST_SPARK_VERSION="1.4.1"
+      env: HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.4.1"
     - jdk: openjdk7
       scala: 2.10.4
-      env: TEST_SPARK_VERSION="1.4.1"
+      env: HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.4.1"
+    # Spark 1.5.0 and Scala 2.10
     - jdk: openjdk7
       scala: 2.10.4
-      env: TEST_SPARK_VERSION="1.5.0-rc2"
+      env: HADOOP_VERSION="1.0.4" SPARK_VERSION="1.5.0-rc2"
+    - jdk: openjdk7
+      scala: 2.10.4
+      env: HADOOP_VERSION="1.2.1" SPARK_VERSION="1.5.0-rc2"
+    - jdk: openjdk7
+      scala: 2.10.4
+      env: HADOOP_VERSION="2.2.0" SPARK_VERSION="1.5.0-rc2"
+    # Spark 1.5.0 and Scala 2.11
     - jdk: openjdk7
       scala: 2.11.7
       env: TEST_SPARK_VERSION="1.5.0-rc2"
 script:
-  - sbt -Dspark.testVersion=$TEST_SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test
+  - sbt -Dhadoop.testVersion=$HADOOP_VERSION -Dspark.testVersion=$TEST_SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test
   - sbt ++$TRAVIS_SCALA_VERSION scalastyle
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,10 @@ val testSparkVersion = settingKey[String]("The version of Spark to test against.
 
 testSparkVersion := sys.props.getOrElse("spark.testVersion", sparkVersion.value)
 
+val testHadoopVersion = settingKey[String]("The version of Hadoop to test against.")
+
+testHadoopVersion := sys.props.getOrElse("hadoop.testVersion", "2.2.0")
+
 resolvers += "Spark 1.5.0 RC2 Staging" at "https://repository.apache.org/content/repositories/orgapachespark-1141"
 
 spAppendScalaVersion := true
@@ -34,8 +38,9 @@ libraryDependencies ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "org.apache.spark" %% "spark-core" % testSparkVersion.value % "test",
-  "org.apache.spark" %% "spark-sql" % testSparkVersion.value % "test"
+  "org.apache.hadoop" % "hadoop-client" % testHadoopVersion.value % "test",
+  "org.apache.spark" %% "spark-core" % testSparkVersion.value % "test" exclude("org.apache.hadoop", "hadoop-client"),
+  "org.apache.spark" %% "spark-sql" % testSparkVersion.value % "test" exclude("org.apache.hadoop", "hadoop-client")
 )
 
 publishMavenStyle := true

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ sparkComponents := Seq("sql")
 
 libraryDependencies ++= Seq(
   "org.apache.avro" % "avro" % "1.7.6" exclude("org.mortbay.jetty", "servlet-api"),
-  "org.apache.avro" % "avro-mapred" % "1.7.7" classifier "hadoop2" % "provided" exclude("org.mortbay.jetty", "servlet-api"),
+  "org.apache.avro" % "avro-mapred" % "1.7.7"  % "provided" classifier("hadoop2") exclude("org.mortbay.jetty", "servlet-api"),
   "org.scalatest" %% "scalatest" % "2.2.1" % "test",
   "commons-io" % "commons-io" % "2.4" % "test"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ sparkComponents := Seq("sql")
 
 libraryDependencies ++= Seq(
   "org.apache.avro" % "avro" % "1.7.6" exclude("org.mortbay.jetty", "servlet-api"),
-  "org.apache.avro" % "avro-mapred" % "1.7.7" % "provided" exclude("org.mortbay.jetty", "servlet-api"),
+  "org.apache.avro" % "avro-mapred" % "1.7.7" classifier "hadoop2" % "provided" exclude("org.mortbay.jetty", "servlet-api"),
   "org.scalatest" %% "scalatest" % "2.2.1" % "test",
   "commons-io" % "commons-io" % "2.4" % "test"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ sparkComponents := Seq("sql")
 
 libraryDependencies ++= Seq(
   "org.apache.avro" % "avro" % "1.7.6" exclude("org.mortbay.jetty", "servlet-api"),
-  "org.apache.avro" % "avro-mapred" % "1.7.6"  classifier "hadoop2"  exclude("org.mortbay.jetty", "servlet-api"),
+  "org.apache.avro" % "avro-mapred" % "1.7.7" % "provided" exclude("org.mortbay.jetty", "servlet-api"),
   "org.scalatest" %% "scalatest" % "2.2.1" % "test",
   "commons-io" % "commons-io" % "2.4" % "test"
 )

--- a/src/main/scala/com/databricks/spark/avro/AvroOutputWriter.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroOutputWriter.scala
@@ -29,8 +29,9 @@ import org.apache.avro.generic.GenericRecord
 import org.apache.avro.{Schema, SchemaBuilder}
 import org.apache.avro.mapred.AvroKey
 import org.apache.avro.mapreduce.AvroKeyOutputFormat
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.io.NullWritable
-import org.apache.hadoop.mapreduce.{RecordWriter, TaskAttemptContext}
+import org.apache.hadoop.mapreduce.{TaskAttemptID, RecordWriter, TaskAttemptContext}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.sources.OutputWriter
 import org.apache.spark.sql.types._
@@ -54,14 +55,26 @@ private[avro] class AvroOutputWriter(
 
       override def getDefaultWorkFile(context: TaskAttemptContext, extension: String): Path = {
         val uniqueWriteJobId = context.getConfiguration.get("spark.sql.sources.writeJobUUID")
-        val split = context.getTaskAttemptID.getTaskID.getId
+        val taskAttemptId: TaskAttemptID = {
+          // Use reflection to get the TaskAttemptID. This is necessary because TaskAttemptContext
+          // is a class in Hadoop 1.x and an interface in Hadoop 2.x.
+          val method = context.getClass.getMethod("getTaskAttemptID")
+          method.invoke(context).asInstanceOf[TaskAttemptID]
+        }
+        val split = taskAttemptId.getTaskID.getId
         new Path(path, f"part-r-$split%05d-$uniqueWriteJobId$extension")
       }
 
       @throws(classOf[IOException])
       override def getAvroFileOutputStream(c: TaskAttemptContext): OutputStream = {
         val path = getDefaultWorkFile(context, ".avro")
-        path.getFileSystem(context.getConfiguration).create(path)
+        val configuration: Configuration = {
+          // Use reflection to get the Configuration. This is necessary because TaskAttemptContext
+          // is a class in Hadoop 1.x and an interface in Hadoop 2.x.
+          val method = context.getClass.getMethod("getConfiguration")
+          method.invoke(context).asInstanceOf[Configuration]
+        }
+        path.getFileSystem(configuration).create(path)
       }
 
     }.getRecordWriter(context)


### PR DESCRIPTION
This commit allows us to publish one `spark-avro` artifact which is built against a fixed Hadoop version but which works with both Hadoop 1.x and 2.x. In the past, we published separate artifacts for Hadoop 1.x and 2.x in order to work around a binary incompatibility in `TaskAttemptContext` (see #19). This patch works around the incompatibility using reflection, similar to https://github.com/apache/spark/pull/6599.

In order to make this testable, this patch also modifies our SBT build and Travis configuration so that the test Hadoop dependencies can be configured separately from the compile dependency.

I made a similar fix in `spark-redshift`: https://github.com/databricks/spark-redshift/pull/58