### PR TITLE
Expose the GenericRecord to Row conversion - #88

### DIFF
--- a/src/main/scala/com/databricks/spark/avro/AvroRelation.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroRelation.scala
@@ -123,62 +123,8 @@ private[avro] class AvroRelation(
           classOf[org.apache.avro.mapred.AvroInputFormat[GenericRecord]],
           classOf[org.apache.avro.mapred.AvroWrapper[GenericRecord]],
           classOf[org.apache.hadoop.io.NullWritable]).keys.map(_.datum())
-          .mapPartitions { records =>
-            if (records.isEmpty) {
-              Iterator.empty
-            } else {
-              val firstRecord = records.next()
-              val superSchema = firstRecord.getSchema // the schema of the actual record
-              // the fields that are actually required along with their converters
-              val avroFieldMap = superSchema.getFields.map(f => (f.name, f)).toMap
-
-              new Iterator[Row] {
-                private[this] val baseIterator = records
-                private[this] var currentRecord = firstRecord
-                private[this] val rowBuffer = new Array[Any](requiredColumns.length)
-                // A micro optimization to avoid allocating a WrappedArray per row.
-                private[this] val bufferSeq = rowBuffer.toSeq
-
-                // An array of functions that pull a column out of an avro record and puts the
-                // converted value into the correct slot of the rowBuffer.
-                private[this] val fieldExtractors = requiredColumns.zipWithIndex.map {
-                  case (columnName, idx) =>
-                    // Spark SQL should not pass us invalid columns
-                    val field =
-                      avroFieldMap.getOrElse(
-                        columnName,
-                        throw new AssertionError(s"Invalid column $columnName"))
-                    val converter = SchemaConverters.createConverterToSQL(field.schema)
-
-                    (record: GenericRecord) => rowBuffer(idx) = converter(record.get(field.pos()))
-                }
-
-                private def advanceNextRecord() = {
-                  if (baseIterator.hasNext) {
-                    currentRecord = baseIterator.next()
-                    true
-                  } else {
-                    false
-                  }
-                }
-
-                def hasNext = {
-                  currentRecord != null || advanceNextRecord()
-                }
-
-                def next() = {
-                  assert(hasNext)
-                  var i = 0
-                  while (i < fieldExtractors.length) {
-                    fieldExtractors(i)(currentRecord)
-                    i += 1
-                  }
-                  currentRecord = null
-                  Row.fromSeq(bufferSeq)
-                }
-              }
-            }
-        }))
+          .toRowRDD(requiredColumns)
+        ))
     }
   }
 

--- a/src/main/scala/com/databricks/spark/avro/AvroRelation.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroRelation.scala
@@ -117,14 +117,14 @@ private[avro] class AvroRelation(
       sqlContext.sparkContext.emptyRDD[Row]
     } else {
       new UnionRDD[Row](sqlContext.sparkContext,
-      inputs.map(path =>
-        sqlContext.sparkContext.hadoopFile(
+      inputs.map(path => {
+        val wrappedAvroRDD = sqlContext.sparkContext.hadoopFile(
           path.getPath.toString,
           classOf[org.apache.avro.mapred.AvroInputFormat[GenericRecord]],
           classOf[org.apache.avro.mapred.AvroWrapper[GenericRecord]],
-          classOf[org.apache.hadoop.io.NullWritable]).keys.map(_.datum())
-          .toRowRDD(requiredColumns)
-        ))
+          classOf[org.apache.hadoop.io.NullWritable])
+        AvroUtil.convertRecordRDDToRowRDD(wrappedAvroRDD.keys.map(_.datum()), requiredColumns)
+      }))
     }
   }
 

--- a/src/main/scala/com/databricks/spark/avro/AvroUtil.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroUtil.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Databricks
+ * Copyright 2014 Databricks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,20 +31,29 @@ object AvroUtil {
   /**
    * Create a DataFrame from an RDD of GenericRecords, with columns based on the provided schema
    */
-  def createDataFrame(sqlContext: SQLContext, rdd: RDD[GenericRecord], schema: Schema): DataFrame = {
+  def createDataFrame(
+      sqlContext: SQLContext,
+      rdd: RDD[GenericRecord],
+      schema: Schema): DataFrame = {
     sqlContext.createDataFrame(
       convertRecordRDDToRowRDD(rdd, schema.getFields.map(_.name()).toArray),
       SchemaConverters.toSqlType(schema).dataType.asInstanceOf[StructType])
   }
 
   /**
-   * Java API to create a DataFrame from an RDD of GenericRecords, with columns based on the provided schema.
+   * Java API to create a DataFrame from an RDD of GenericRecords, with columns based on the
+   * provided schema.
    */
-  def createDataFrame(sqlContext: SQLContext, rdd: JavaRDD[GenericRecord], schema: Schema): DataFrame = {
+  def createDataFrame(
+      sqlContext: SQLContext,
+      rdd: JavaRDD[GenericRecord],
+      schema: Schema): DataFrame = {
     createDataFrame(sqlContext, rdd.rdd, schema)
   }
 
-  private[avro] def convertRecordRDDToRowRDD(rdd: RDD[GenericRecord], requiredColumns: Array[String]): RDD[Row] = {
+  private[avro] def convertRecordRDDToRowRDD(
+      rdd: RDD[GenericRecord],
+      requiredColumns: Array[String]): RDD[Row] = {
     rdd.mapPartitions { records =>
       if (records.isEmpty) {
         Iterator.empty

--- a/src/main/scala/com/databricks/spark/avro/AvroUtil.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroUtil.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2015 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.databricks.spark.avro
+
+import scala.collection.Iterator
+import scala.collection.JavaConversions._
+
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericRecord
+
+import org.apache.spark.api.java.JavaRDD
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+
+object AvroUtil {
+
+  /**
+   * Create a DataFrame from an RDD of GenericRecords, with columns based on the provided schema
+   */
+  def createDataFrame(sqlContext: SQLContext, rdd: RDD[GenericRecord], schema: Schema): DataFrame = {
+    sqlContext.createDataFrame(
+      convertRecordRDDToRowRDD(rdd, schema.getFields.map(_.name()).toArray),
+      SchemaConverters.toSqlType(schema).dataType.asInstanceOf[StructType])
+  }
+
+  /**
+   * Java API to create a DataFrame from an RDD of GenericRecords, with columns based on the provided schema.
+   */
+  def createDataFrame(sqlContext: SQLContext, rdd: JavaRDD[GenericRecord], schema: Schema): DataFrame = {
+    createDataFrame(sqlContext, rdd.rdd, schema)
+  }
+
+  private[avro] def convertRecordRDDToRowRDD(rdd: RDD[GenericRecord], requiredColumns: Array[String]): RDD[Row] = {
+    rdd.mapPartitions { records =>
+      if (records.isEmpty) {
+        Iterator.empty
+      } else {
+        val firstRecord = records.next()
+        val superSchema = firstRecord.getSchema // the schema of the actual record
+        // the fields that are actually required along with their converters
+        val avroFieldMap = superSchema.getFields.map(f => (f.name, f)).toMap
+
+        new Iterator[Row] {
+          private[this] val baseIterator = records
+          private[this] var currentRecord = firstRecord
+          private[this] val rowBuffer = new Array[Any](requiredColumns.length)
+          // A micro optimization to avoid allocating a WrappedArray per row.
+          private[this] val bufferSeq = rowBuffer.toSeq
+
+          // An array of functions that pull a column out of an avro record and puts the
+          // converted value into the correct slot of the rowBuffer.
+          private[this] val fieldExtractors = requiredColumns.zipWithIndex.map {
+            case (columnName, idx) =>
+              // Spark SQL should not pass us invalid columns
+              val field =
+                avroFieldMap.getOrElse(
+                  columnName,
+                  throw new AssertionError(s"Invalid column $columnName"))
+              val converter = SchemaConverters.createConverterToSQL(field.schema)
+
+              (record: GenericRecord) => rowBuffer(idx) = converter(record.get(field.pos()))
+          }
+
+          private def advanceNextRecord() = {
+            if (baseIterator.hasNext) {
+              currentRecord = baseIterator.next()
+              true
+            } else {
+              false
+            }
+          }
+
+          def hasNext = {
+            currentRecord != null || advanceNextRecord()
+          }
+
+          def next() = {
+            assert(hasNext)
+            var i = 0
+            while (i < fieldExtractors.length) {
+              fieldExtractors(i)(currentRecord)
+              i += 1
+            }
+            currentRecord = null
+            Row.fromSeq(bufferSeq)
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.types._
  * This object contains method that are used to convert sparkSQL schemas to avro schemas and vice
  * versa.
  */
-private object SchemaConverters {
+private[avro] object SchemaConverters {
 
   case class SchemaType(dataType: DataType, nullable: Boolean)
 

--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.types._
  * This object contains method that are used to convert sparkSQL schemas to avro schemas and vice
  * versa.
  */
-private[avro] object SchemaConverters {
+private object SchemaConverters {
 
   case class SchemaType(dataType: DataType, nullable: Boolean)
 

--- a/src/main/scala/com/databricks/spark/avro/package.scala
+++ b/src/main/scala/com/databricks/spark/avro/package.scala
@@ -50,7 +50,8 @@ package object avro {
   }
 
   /**
-   * Adds a signature to [[SQLContext.createDataFrame]], to create a DataFrame from an RDD of GenericRecords.
+   * Adds a signature to [[SQLContext.createDataFrame]], to create a DataFrame from an RDD of
+   * GenericRecords.
    */
   implicit class AvroSQLContext(sqlContext: SQLContext) {
     def createDataFrame(rdd: RDD[GenericRecord], schema: Schema): DataFrame = {

--- a/src/main/scala/com/databricks/spark/avro/package.scala
+++ b/src/main/scala/com/databricks/spark/avro/package.scala
@@ -15,7 +15,12 @@
  */
 package com.databricks.spark
 
-import org.apache.spark.sql.{SQLContext, DataFrameReader, DataFrameWriter, DataFrame}
+import org.apache.avro.generic.GenericRecord
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql._
+import scala.collection.JavaConversions._
+
+import scala.collection.Iterator
 
 package object avro {
 
@@ -44,4 +49,68 @@ package object avro {
   implicit class AvroDataFrameReader(reader: DataFrameReader) {
     def avro: String => DataFrame = reader.format("com.databricks.spark.avro").load
   }
+
+  /**
+   * Adds a method, `toRowRDD`, to RDDs of GenericRecords.  This allows you to convert it to
+   * an RDD of Row (and, by implication, a DataFrame).
+   */
+  implicit class GenericRecordRDD(rdd: RDD[GenericRecord]) {
+    def toRowRDD(requiredColumns: Array[String]): RDD[Row] = rdd.mapPartitions { records =>
+      if (records.isEmpty) {
+        Iterator.empty
+      } else {
+        val firstRecord = records.next()
+        val superSchema = firstRecord.getSchema // the schema of the actual record
+        // the fields that are actually required along with their converters
+        val avroFieldMap = superSchema.getFields.map(f => (f.name, f)).toMap
+
+        new Iterator[Row] {
+          private[this] val baseIterator = records
+          private[this] var currentRecord = firstRecord
+          private[this] val rowBuffer = new Array[Any](requiredColumns.length)
+          // A micro optimization to avoid allocating a WrappedArray per row.
+          private[this] val bufferSeq = rowBuffer.toSeq
+
+          // An array of functions that pull a column out of an avro record and puts the
+          // converted value into the correct slot of the rowBuffer.
+          private[this] val fieldExtractors = requiredColumns.zipWithIndex.map {
+            case (columnName, idx) =>
+              // Spark SQL should not pass us invalid columns
+              val field =
+                avroFieldMap.getOrElse(
+                  columnName,
+                  throw new AssertionError(s"Invalid column $columnName"))
+              val converter = SchemaConverters.createConverterToSQL(field.schema)
+
+              (record: GenericRecord) => rowBuffer(idx) = converter(record.get(field.pos()))
+          }
+
+          private def advanceNextRecord() = {
+            if (baseIterator.hasNext) {
+              currentRecord = baseIterator.next()
+              true
+            } else {
+              false
+            }
+          }
+
+          def hasNext = {
+            currentRecord != null || advanceNextRecord()
+          }
+
+          def next() = {
+            assert(hasNext)
+            var i = 0
+            while (i < fieldExtractors.length) {
+              fieldExtractors(i)(currentRecord)
+              i += 1
+            }
+            currentRecord = null
+            Row.fromSeq(bufferSeq)
+          }
+        }
+      }
+    }
+  }
+
 }

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -300,6 +300,14 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
     }
   }
 
+  test("convert generic records to dataframe") {
+    val record = new SerializableRecord()
+    record.put("content", "abc")
+    val recordRdd = sqlContext.sparkContext.parallelize(Seq[GenericRecord](record))
+    val df = sqlContext.createDataFrame(recordRdd, record.getSchema)
+    assert(df.count() == 1)
+  }
+
   test("converting some specific sparkSQL types to avro") {
     TestUtils.withTempDir { tempDir =>
       val testSchema = StructType(Seq(

--- a/src/test/scala/com/databricks/spark/avro/SerializableRecord.scala
+++ b/src/test/scala/com/databricks/spark/avro/SerializableRecord.scala
@@ -1,0 +1,43 @@
+package com.databricks.spark.avro
+
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericRecord
+
+class SerializableRecord extends GenericRecord with Serializable {
+
+  private var content: String = null
+
+  override def get(key: String): AnyRef = {
+    assert(key == "content")
+    content
+  }
+
+  override def put(key: String, v: scala.Any): Unit = {
+    assert(key == "content")
+    content = v.toString
+  }
+
+  override def get(i: Int): AnyRef = {
+    assert(i == 0)
+    content
+  }
+
+  override def put(i: Int, v: scala.Any): Unit = {
+    assert(i == 0)
+    content = v.toString
+  }
+
+  override def getSchema: Schema = {
+    val parser = new Schema.Parser()
+    parser.parse(
+      """{
+        |  "type": "record",
+        |  "name": "test_record",
+        |  "fields": [{
+        |    "name": "content",
+        |    "type": "string"
+        |  }]
+        |}
+      """.stripMargin)
+  }
+}


### PR DESCRIPTION
This transformation makes it possible to use alternative storage engines (backing the RDD[GenericRecord]) for an Avro backed DataFrame.
