### PR TITLE
Feat no union

### DIFF
--- a/src/main/scala/com/databricks/spark/avro/AvroRelation.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroRelation.scala
@@ -30,10 +30,11 @@ import org.apache.avro.generic.{GenericDatumReader, GenericRecord}
 import org.apache.avro.mapred.{AvroOutputFormat, FsInput}
 import org.apache.avro.mapreduce.AvroJob
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
+import org.apache.hadoop.mapred.{ JobConf, FileInputFormat }
 import org.apache.hadoop.mapreduce.Job
 
 import org.apache.spark.Logging
-import org.apache.spark.rdd.{RDD, UnionRDD}
+import org.apache.spark.rdd.{RDD, HadoopRDD}
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{Row, SQLContext}
@@ -116,69 +117,72 @@ private[avro] class AvroRelation(
     if (inputs.isEmpty) {
       sqlContext.sparkContext.emptyRDD[Row]
     } else {
-      new UnionRDD[Row](sqlContext.sparkContext,
-      inputs.map(path =>
-        sqlContext.sparkContext.hadoopFile(
-          path.getPath.toString,
-          classOf[org.apache.avro.mapred.AvroInputFormat[GenericRecord]],
-          classOf[org.apache.avro.mapred.AvroWrapper[GenericRecord]],
-          classOf[org.apache.hadoop.io.NullWritable]).keys.map(_.datum())
-          .mapPartitions { records =>
-            if (records.isEmpty) {
-              Iterator.empty
-            } else {
-              val firstRecord = records.next()
-              val superSchema = firstRecord.getSchema // the schema of the actual record
-              // the fields that are actually required along with their converters
-              val avroFieldMap = superSchema.getFields.map(f => (f.name, f)).toMap
+      // i have to do this the ugly way because hadoopFile only exposes one path (why?)
+      val job = new JobConf(sqlContext.sparkContext.hadoopConfiguration)
+      FileInputFormat.setInputPaths(job, inputs.map(_.getPath).toArray: _*)
+      new HadoopRDD(
+        sqlContext.sparkContext,
+        job,
+        classOf[org.apache.avro.mapred.AvroInputFormat[GenericRecord]],
+        classOf[org.apache.avro.mapred.AvroWrapper[GenericRecord]],
+        classOf[org.apache.hadoop.io.NullWritable],
+        sqlContext.sparkContext.defaultMinPartitions
+      ).keys.map(_.datum()).mapPartitions { records =>
+        if (records.isEmpty) {
+          Iterator.empty
+        } else {
+          val firstRecord = records.next()
+          val superSchema = firstRecord.getSchema // the schema of the actual record
+          // the fields that are actually required along with their converters
+          val avroFieldMap = superSchema.getFields.map(f => (f.name, f)).toMap
 
-              new Iterator[Row] {
-                private[this] val baseIterator = records
-                private[this] var currentRecord = firstRecord
-                private[this] val rowBuffer = new Array[Any](requiredColumns.length)
-                // A micro optimization to avoid allocating a WrappedArray per row.
-                private[this] val bufferSeq = rowBuffer.toSeq
+          new Iterator[Row] {
+            private[this] val baseIterator = records
+            private[this] var currentRecord = firstRecord
+            private[this] val rowBuffer = new Array[Any](requiredColumns.length)
+            // A micro optimization to avoid allocating a WrappedArray per row.
+            private[this] val bufferSeq = rowBuffer.toSeq
 
-                // An array of functions that pull a column out of an avro record and puts the
-                // converted value into the correct slot of the rowBuffer.
-                private[this] val fieldExtractors = requiredColumns.zipWithIndex.map {
-                  case (columnName, idx) =>
-                    // Spark SQL should not pass us invalid columns
-                    val field =
-                      avroFieldMap.getOrElse(
-                        columnName,
-                        throw new AssertionError(s"Invalid column $columnName"))
-                    val converter = SchemaConverters.createConverterToSQL(field.schema)
+            // An array of functions that pull a column out of an avro record and puts the
+            // converted value into the correct slot of the rowBuffer.
+            private[this] val fieldExtractors = requiredColumns.zipWithIndex.map {
+              case (columnName, idx) =>
+                // Spark SQL should not pass us invalid columns
+                val field =
+                  avroFieldMap.getOrElse(
+                    columnName,
+                    throw new AssertionError(s"Invalid column $columnName"))
+                val converter = SchemaConverters.createConverterToSQL(field.schema)
 
-                    (record: GenericRecord) => rowBuffer(idx) = converter(record.get(field.pos()))
-                }
+                (record: GenericRecord) => rowBuffer(idx) = converter(record.get(field.pos()))
+            }
 
-                private def advanceNextRecord() = {
-                  if (baseIterator.hasNext) {
-                    currentRecord = baseIterator.next()
-                    true
-                  } else {
-                    false
-                  }
-                }
-
-                def hasNext = {
-                  currentRecord != null || advanceNextRecord()
-                }
-
-                def next() = {
-                  assert(hasNext)
-                  var i = 0
-                  while (i < fieldExtractors.length) {
-                    fieldExtractors(i)(currentRecord)
-                    i += 1
-                  }
-                  currentRecord = null
-                  Row.fromSeq(bufferSeq)
-                }
+            private def advanceNextRecord() = {
+              if (baseIterator.hasNext) {
+                currentRecord = baseIterator.next()
+                true
+              } else {
+                false
               }
             }
-        }))
+
+            def hasNext = {
+              currentRecord != null || advanceNextRecord()
+            }
+
+            def next() = {
+              assert(hasNext)
+              var i = 0
+              while (i < fieldExtractors.length) {
+                fieldExtractors(i)(currentRecord)
+                i += 1
+              }
+              currentRecord = null
+              Row.fromSeq(bufferSeq)
+            }
+          }
+        }
+      }
     }
   }
 

--- a/src/main/scala/com/databricks/spark/avro/AvroRelation.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroRelation.scala
@@ -47,7 +47,8 @@ private[avro] class AvroRelation(
   private val IgnoreFilesWithoutExtensionProperty = "avro.mapred.ignore.inputs.without.extension"
   private val recordName = parameters.getOrElse("recordName", "topLevelRecord")
   private val recordNamespace = parameters.getOrElse("recordNamespace", "")
-  private val schemaFromLastPath = parameters.get("schemaFromLastPath").map(_.toBoolean).getOrElse(false)
+  private val schemaFromLastPath = parameters.get("schemaFromLastPath")
+    .map(_.toBoolean).getOrElse(false)
 
   /** needs to be lazy so it is not evaluated when saving since no schema exists at that location */
   private lazy val avroSchema = paths match {

--- a/src/main/scala/com/databricks/spark/avro/AvroRelation.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroRelation.scala
@@ -56,7 +56,8 @@ private[avro] class AvroRelation(
     val schemaPath = schemaFromPath.getOrElse{
       paths match {
         case Array() =>
-          throw new java.io.FileNotFoundException("Cannot infer the schema when no files are present.")
+          throw new java.io.FileNotFoundException(
+            "Cannot infer the schema when no files are present.")
         case array if schemaFromLastPath => array.last
         case array => array.head
       }

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -420,6 +420,25 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
     }
   }
 
+  test("test save and load with path specified for schema") {
+    // Test if load works as expected
+    TestUtils.withTempDir { tempDir =>
+      val df = sqlContext.read.avro(episodesFile)
+      assert(df.count == 8)
+
+      val tempSaveDir = s"$tempDir/save/"
+
+      df.select(df("title"), df("doctor")).write.avro(tempSaveDir)
+      val newDf1 = sqlContext.read.option("schemaFromPath", episodesFile).avro(tempSaveDir)
+      assert(newDf1.count == 8)
+      assert(newDf1.schema == df.schema)
+      val newDf2 = sqlContext.read.avro(tempSaveDir)
+      assert(newDf2.count == 8)
+      assert(newDf2.schema == StructType(Array(StructField("title", StringType, true), StructField("doctor", IntegerType, true))))
+    }
+  }
+
+
   test("test save and load with comma in path") {
     // Test if load works as expected
     TestUtils.withTempDir { tempDir =>

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -419,4 +419,18 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
       assert(newDf.count == 8)
     }
   }
+
+  test("test save and load with comma in path") {
+    // Test if load works as expected
+    TestUtils.withTempDir { tempDir =>
+      val df = sqlContext.read.avro(episodesFile)
+      assert(df.count == 8)
+
+      val tempSaveDir = s"$tempDir/sa,ve/"
+
+      df.write.avro(tempSaveDir)
+      val newDf = sqlContext.read.avro(tempSaveDir)
+      assert(newDf.count == 8)
+    }
+  }
 }

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -440,6 +440,9 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
       val newDf1 = sqlContext.baseRelationToDataFrame(
         new AvroRelation(Array("file://" + tempSaveDir, "file://" + tempSaveDir1), None, None, Map.empty)(sqlContext))
       assert(newDf1.count == 16)
+
+      val newDf2 = sqlContext.read.avro(s"$tempDir/sa,ve*/")
+      assert(newDf2.count == 16)
     }
   }
 }

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -431,6 +431,15 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
       df.write.avro(tempSaveDir)
       val newDf = sqlContext.read.avro(tempSaveDir)
       assert(newDf.count == 8)
+
+      val tempSaveDir1 = s"$tempDir/sa,ve1/"
+      df.write.avro(tempSaveDir1)
+
+      // this ugly hack is sqlContext.avroFile except i would like to pass in multiple paths
+      // with SPARK-10185 multiple paths will work again with sqlContext.read.avro
+      val newDf1 = sqlContext.baseRelationToDataFrame(
+        new AvroRelation(Array("file://" + tempSaveDir, "file://" + tempSaveDir1), None, None, Map.empty)(sqlContext))
+      assert(newDf1.count == 16)
     }
   }
 }


### PR DESCRIPTION
I am not entirely sure why spark-avro creates a RDD for every input path and then merges them together with UnionRDD. Perhaps there is a compelling reason for this,  and if so then this pullreq is probably misguided.

We noticed that when reading using globs like /data/\* that many RDDs were created and for each the Configuration object would get broadcast. In one situation this would go on for 30 mins or so  (or maybe longer, i killed it).

So given that AvroInputFormat already has excellent build-in support for globs and multiple paths, why not use it, and lose the UnionRDD. Thats the basic idea of this pullreq.

See also here:
https://www.mail-archive.com/user@spark.apache.org/msg39393.html
