### PR TITLE
ISSUE #105: support unions of a single type

### DIFF
--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -81,6 +81,8 @@ private object SchemaConverters {
             toSqlType(Schema.createUnion(remainingUnionTypes)).copy(nullable = true)
           }
         } else avroSchema.getTypes.map(_.getType) match {
+          case Seq(t1) =>
+            toSqlType(avroSchema.getTypes.get(0)).copy(nullable = true)
           case Seq(t1, t2) if Set(t1, t2) == Set(INT, LONG) =>
             SchemaType(LongType, nullable = false)
           case Seq(t1, t2) if Set(t1, t2) == Set(FLOAT, DOUBLE) =>
@@ -176,6 +178,8 @@ private object SchemaConverters {
             createConverterToSQL(Schema.createUnion(remainingUnionTypes))
           }
         } else schema.getTypes.map(_.getType) match {
+          case Seq(t1) =>
+            createConverterToSQL(schema.getTypes.get(0))
           case Seq(t1, t2) if Set(t1, t2) == Set(INT, LONG) =>
             (item: Any) => {
               item match {

--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -82,7 +82,7 @@ private object SchemaConverters {
           }
         } else avroSchema.getTypes.map(_.getType) match {
           case Seq(t1) =>
-            toSqlType(avroSchema.getTypes.get(0)).copy(nullable = true)
+            toSqlType(avroSchema.getTypes.get(0))
           case Seq(t1, t2) if Set(t1, t2) == Set(INT, LONG) =>
             SchemaType(LongType, nullable = false)
           case Seq(t1, t2) if Set(t1, t2) == Set(FLOAT, DOUBLE) =>


### PR DESCRIPTION
#105 
Adds support in SchemaConverters for unions of a single type.
