### PR TITLE
Update Travis build matrix to replace 1.5.0-rc2 with 1.5.0 and add 1.6.0 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,17 +19,23 @@ matrix:
     # These two cases will fail in Travis until SPARK-10330 is fixed.
     # - jdk: openjdk7
     #   scala: 2.10.4
-    #   env: TEST_HADOOP_VERSION="1.0.4" TEST_SPARK_VERSION="1.5.0-rc2"
+    #   env: TEST_HADOOP_VERSION="1.0.4" TEST_SPARK_VERSION="1.5.0"
     # - jdk: openjdk7
     #   scala: 2.10.4
-    #   env: TEST_HADOOP_VERSION="1.2.1" TEST_SPARK_VERSION="1.5.0-rc2"
+    #   env: TEST_HADOOP_VERSION="1.2.1" TEST_SPARK_VERSION="1.5.0"
     - jdk: openjdk7
       scala: 2.10.4
-      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.5.0-rc2"
+      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.5.0"
+    - jdk: openjdk7
+      scala: 2.10.4
+      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.6.0"
+    - jdk: openjdk7
+      scala: 2.10.4
+      env: TEST_HADOOP_VERSION="1.2.1" TEST_SPARK_VERSION="1.6.0"
     # Spark 1.5.0 and Scala 2.11
     - jdk: openjdk7
       scala: 2.11.7
-      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.5.0-rc2"
+      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.5.0"
 script:
   - sbt -Dhadoop.testVersion=$TEST_HADOOP_VERSION -Dspark.testVersion=$TEST_SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test
   - sbt ++$TRAVIS_SCALA_VERSION scalastyle

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,6 @@ matrix:
     - jdk: openjdk7
       scala: 2.10.4
       env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.6.0"
-    - jdk: openjdk7
-      scala: 2.10.4
-      env: TEST_HADOOP_VERSION="1.2.1" TEST_SPARK_VERSION="1.6.0"
     # Spark 1.5.0 and Scala 2.11
     - jdk: openjdk7
       scala: 2.11.7

--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,6 @@ val testHadoopVersion = settingKey[String]("The version of Hadoop to test agains
 
 testHadoopVersion := sys.props.getOrElse("hadoop.testVersion", "2.2.0")
 
-resolvers += "Spark 1.5.0 RC2 Staging" at "https://repository.apache.org/content/repositories/orgapachespark-1141"
-
 spAppendScalaVersion := true
 
 spIncludeMaven := true


### PR DESCRIPTION
This patch updates the Travis build matrix to replace 1.5.0-rc2 with 1.5.0 and add 1.6.0 builds.