### PR TITLE
Add support for complex union types

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ disk. The supported types are `uncompressed`, `snappy`, and `deflate`. You can a
 
 ## Supported types for Avro -> Spark SQL conversion
 
-This library supports reading all Avro types, with the exception of complex `union` types. It uses the following mapping from Avro types to Spark SQL types:
+This library supports reading all Avro types. It uses the following mapping from Avro types to Spark SQL types:
 
 | Avro type | Spark SQL type |
 | --------- |----------------|
@@ -101,12 +101,15 @@ This library supports reading all Avro types, with the exception of complex `uni
 | array     | ArrayType      |
 | map       | MapType        |
 | fixed     | BinaryType     |
+| union     | See below      |
 
-In addition to the types listed above, it supports reading of three types of `union` types:
+In addition to the types listed above, it supports reading `union` types. The following three types are considered basic `union` types:
 
-1. `union(int, long)`
-2. `union(float, double)`
-3. `union(something, null)`, where `something` is one of the supported Avro types listed above or is one of the supported `union` types.
+1. `union(int, long)` will be mapped to `LongType`.
+2. `union(float, double)` will be mapped to `DoubleType`.
+3. `union(something, null)`, where `something` is any supported Avro type. This will be mapped to the same Spark SQL type as that of `something`, with `nullable` set to `true`.
+
+All other `union` types are considered complex. They will be mapped to `StructType` where field names are `member0`, `member1`, etc., in accordance with members of the `union`. This is consistent with the behavior when reading Parquet files.
 
 At the moment, it ignores docs, aliases and other properties present in the Avro file.
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ In addition to the types listed above, it supports reading `union` types. The fo
 2. `union(float, double)` will be mapped to `DoubleType`.
 3. `union(something, null)`, where `something` is any supported Avro type. This will be mapped to the same Spark SQL type as that of `something`, with `nullable` set to `true`.
 
-All other `union` types are considered complex. They will be mapped to `StructType` where field names are `member0`, `member1`, etc., in accordance with members of the `union`. This is consistent with the behavior when reading Parquet files.
+All other `union` types are considered complex. They will be mapped to `StructType` where field names are `member0`, `member1`, etc., in accordance with members of the `union`. This is consistent with the behavior when converting between Avro and Parquet.
 
 At the moment, it ignores docs, aliases and other properties present in the Avro file.
 

--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -90,8 +90,17 @@ object SchemaConverters {
             SchemaType(LongType, nullable = false)
           case Seq(t1, t2) if Set(t1, t2) == Set(FLOAT, DOUBLE) =>
             SchemaType(DoubleType, nullable = false)
-          case other => throw new IncompatibleSchemaException(
-            s"This mix of union types is not supported (see README): $other")
+          case _ =>
+            // Convert complex unions to struct types where field names are member0, member1, etc.
+            // This is consistent with the behavior when reading Parquet files.
+            val fields = avroSchema.getTypes.zipWithIndex map {
+              case (s, i) =>
+                val schemaType = toSqlType(s)
+                // All fields are nullable because only one of them is set at a time
+                StructField(s"member$i", schemaType.dataType, nullable = true)
+            }
+
+            SchemaType(StructType(fields), nullable = false)
         }
 
       case other => throw new IncompatibleSchemaException(s"Unsupported type $other")
@@ -264,12 +273,29 @@ object SchemaConverters {
                   case f: java.lang.Float => new java.lang.Double(f.doubleValue())
                 }
               }
-            case other => throw new IncompatibleSchemaException(
-              s"Cannot convert Avro schema to catalyst type because schema at path " +
-                s"${path.mkString(".")} is not compatible (avroType = $other, sqlType = $sqlType)" +
-                s" or this mix of union types is not supported (see README):\n" +
-                s"Source Avro schema: $sourceAvroSchema.\n" +
-                s"Target Catalyst type: $targetSqlType")
+            case other =>
+              sqlType match {
+                case t: StructType if t.fields.length == avroSchema.getTypes.size =>
+                  val fieldConverters = t.fields zip avroSchema.getTypes map {
+                    case (field, schema) =>
+                      createConverter(schema, field.dataType, path :+ field.name)
+                  }
+
+                  (item: AnyRef) => if (item == null) {
+                    null
+                  } else {
+                    val i = GenericData.get().resolveUnion(avroSchema, item)
+                    val converted = new Array[Any](fieldConverters.length)
+                    converted(i) = fieldConverters(i)(item)
+                    new GenericRow(converted)
+                  }
+                case _ => throw new IncompatibleSchemaException(
+                  s"Cannot convert Avro schema to catalyst type because schema at path " +
+                    s"${path.mkString(".")} is not compatible " +
+                    s"(avroType = $other, sqlType = $sqlType). \n" +
+                    s"Source Avro schema: $sourceAvroSchema.\n" +
+                    s"Target Catalyst type: $targetSqlType")
+              }
           }
         case (left, right) =>
           throw new IncompatibleSchemaException(

--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -92,8 +92,8 @@ object SchemaConverters {
             SchemaType(DoubleType, nullable = false)
           case _ =>
             // Convert complex unions to struct types where field names are member0, member1, etc.
-            // This is consistent with the behavior when reading Parquet files.
-            val fields = avroSchema.getTypes.zipWithIndex map {
+            // This is consistent with the behavior when converting between Avro and Parquet.
+            val fields = avroSchema.getTypes.zipWithIndex.map {
               case (s, i) =>
                 val schemaType = toSqlType(s)
                 // All fields are nullable because only one of them is set at a time
@@ -276,7 +276,7 @@ object SchemaConverters {
             case other =>
               sqlType match {
                 case t: StructType if t.fields.length == avroSchema.getTypes.size =>
-                  val fieldConverters = t.fields zip avroSchema.getTypes map {
+                  val fieldConverters = t.fields.zip(avroSchema.getTypes).map {
                     case (field, schema) =>
                       createConverter(schema, field.dataType, path :+ field.name)
                   }

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -22,14 +22,13 @@ import java.nio.file.Files
 import java.sql.Timestamp
 import java.util.UUID
 
-import org.apache.avro.generic.GenericData.{EnumSymbol, Fixed}
-
 import scala.collection.JavaConversions._
 
 import com.databricks.spark.avro.SchemaConverters.IncompatibleSchemaException
 import org.apache.avro.Schema
 import org.apache.avro.Schema.{Field, Type}
 import org.apache.avro.file.DataFileWriter
+import org.apache.avro.generic.GenericData.{EnumSymbol, Fixed}
 import org.apache.avro.generic.{GenericData, GenericDatumWriter, GenericRecord}
 import org.apache.commons.io.FileUtils
 

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -22,6 +22,8 @@ import java.nio.file.Files
 import java.sql.Timestamp
 import java.util.UUID
 
+import org.apache.avro.generic.GenericData.{EnumSymbol, Fixed}
+
 import scala.collection.JavaConversions._
 
 import com.databricks.spark.avro.SchemaConverters.IncompatibleSchemaException
@@ -134,29 +136,41 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
     }
   }
 
-  test("Incorrect Union Type") {
+  test("Complex Union Type") {
     TestUtils.withTempDir { dir =>
-      val BadUnionType = Schema.createUnion(
-        List(Schema.create(Type.INT), Schema.create(Type.STRING)))
-      val fixedSchema = Schema.createFixed("fixed_name", "doc", "namespace", 20)
-      val fixedUnionType = Schema.createUnion(List(fixedSchema,Schema.create(Type.NULL)))
-      val fields = Seq(new Field("field1", BadUnionType, "doc", null),
-        new Field("fixed", fixedUnionType, "doc", null),
-        new Field("bytes", Schema.create(Type.BYTES), "doc", null))
+      val fixedSchema = Schema.createFixed("fixed_name", "doc", "namespace", 4)
+      val enumSchema = Schema.createEnum("enum_name", "doc", "namespace", List("e1", "e2"))
+      val complexUnionType = Schema.createUnion(
+        List(Schema.create(Type.INT), Schema.create(Type.STRING), fixedSchema, enumSchema))
+      val fields = Seq(
+        new Field("field1", complexUnionType, "doc", null),
+        new Field("field2", complexUnionType, "doc", null),
+        new Field("field3", complexUnionType, "doc", null),
+        new Field("field4", complexUnionType, "doc", null)
+      )
       val schema = Schema.createRecord("name", "docs", "namespace", false)
       schema.setFields(fields)
       val datumWriter = new GenericDatumWriter[GenericRecord](schema)
       val dataFileWriter = new DataFileWriter[GenericRecord](datumWriter)
       dataFileWriter.create(schema, new File(s"$dir.avro"))
       val avroRec = new GenericData.Record(schema)
-      avroRec.put("field1", "Hope that was not load bearing")
-      avroRec.put("bytes", ByteBuffer.wrap(Array[Byte]()))
+      val field1 = 1234
+      val field2 = "Hope that was not load bearing"
+      val field3 = Array[Byte](1, 2, 3, 4)
+      val field4 = "e2"
+      avroRec.put("field1", field1)
+      avroRec.put("field2", field2)
+      avroRec.put("field3", new Fixed(fixedSchema, field3))
+      avroRec.put("field4", new EnumSymbol(enumSchema, field4))
       dataFileWriter.append(avroRec)
       dataFileWriter.flush()
       dataFileWriter.close()
-      intercept[IncompatibleSchemaException] {
-        spark.read.avro(s"$dir.avro")
-      }
+
+      val df = spark.sqlContext.read.avro(s"$dir.avro")
+      assertResult(field1)(df.selectExpr("field1.member0").first().get(0))
+      assertResult(field2)(df.selectExpr("field2.member1").first().get(0))
+      assertResult(field3)(df.selectExpr("field3.member2").first().get(0))
+      assertResult(field4)(df.selectExpr("field4.member3").first().get(0))
     }
   }
 


### PR DESCRIPTION
A complex union will be converted to a struct type where field names are `member0`, `member1`, etc., in accordance with members of the union. This is consistent with the behavior when reading Parquet files. Field values are resolved following existing schema translation rules. The test case is a good example of this translation.
