### PR TITLE
convert array type instead of just casting

### DIFF
--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -160,7 +160,9 @@ object SchemaConverters {
         (item: Any) => if (item == null) {
           null
         } else {
-          item.asInstanceOf[GenericData.Array[Any]].map(elementConverter)
+          val converted = item.asInstanceOf[java.util.Collection[Any]]
+          val genericWrapper = new GenericData.Array(schema, converted)
+          genericWrapper.map(elementConverter)
         }
       case MAP =>
         val valueConverter = createConverterToSQL(schema.getValueType)


### PR DESCRIPTION
This is to fix a problem I was having when using https://github.com/julianpeeters/avrohugger case classes with spark. The problem stems from the fact that no native iterable scala type(List, Seq, etc) extends GenericData.Array, so using case classes for avro instead of java Specific classes doesn't work.

I'm happy to wrap this up and contribute if someone can point me to what needs to be done. If there is a better way to handle being able to use scala case classes with avro, I'm open to suggestions as well.
