### PR TITLE
Add codecov.yml file

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+comment:
+  layout: header, changes, diff
+coverage:
+  status:
+    patch: false
+    project:
+      default:
+        target: 90


### PR DESCRIPTION
Codecov replaced its UI-based configuration with a [codecov.yml](https://github.com/codecov/support/wiki/codecov.yml) file, so this patch adds that configuration so that our custom coverage target is used by the PR status check.