### PR TITLE
Marks spark-avro 3.0.0 as "to be released"

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ This documentation is for Spark 1.4+ and 2.0.
 This library has different versions for Spark 1.2, 1.3, 1.4+, and 2.0:
 
 | Spark Version | Compatible version of Avro Data Source for Spark |
-| ------------- |----------------------|
-| `1.2`         | `0.2.0`              |
-| `1.3`         | `1.0.0`              |
-| `1.4+`        | `2.0.1`              |
-| `2.0`         | `3.0.0`              |
+| ------------- | ------------------------------------------------ |
+| `1.2`         | `0.2.0`                                          |
+| `1.3`         | `1.0.0`                                          |
+| `1.4+`        | `2.0.1`                                          |
+| `2.0`         | `3.0.0` (to be released)                         |
 
 ## Linking
 


### PR DESCRIPTION
Since Spark 2.0.0 hasn't been released yet, we only made a 3.0.0-preview ([1][1], [2][2]) release recently. Should update README.md to point out that spark-avro 3.0.0 hasn't been officially released yet.

[1]: http://search.maven.org/#artifactdetails|com.databricks|spark-avro_2.11|3.0.0-preview|jar
[2]: http://search.maven.org/#artifactdetails|com.databricks|spark-avro_2.10|3.0.0-preview|jar