### PR TITLE
Respect avro.mapred.ignore.inputs.without.extension

### DIFF
--- a/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
@@ -143,6 +143,10 @@ private[avro] class DefaultSource extends FileFormat with DataSourceRegister {
     (file: PartitionedFile) => {
       val conf = broadcastedConf.value.value
 
+      // TODO Removes this check once `FileFormat` gets a general file filtering interface method.
+      // Doing input file filtering is improper because we may generate empty tasks that process no
+      // input files but stress the scheduler. We should probably add a more general input file
+      // filtering mechanism for `FileFormat` data sources. See SPARK-16317.
       if (
         conf.getBoolean(IgnoreFilesWithoutExtensionProperty, true) &&
         !file.filePath.endsWith(".avro")
@@ -160,9 +164,9 @@ private[avro] class DefaultSource extends FileFormat with DataSourceRegister {
             val avroField = Option(avroSchema.getField(field.name)).getOrElse {
               throw new IllegalArgumentException(
                 s"""Cannot find required column ${field.name} in Avro schema:"
-                    |
-                 |${avroSchema.toString(true)}
-               """.stripMargin
+                   |
+                   |${avroSchema.toString(true)}
+                 """.stripMargin
               )
             }
 

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -18,6 +18,7 @@ package com.databricks.spark.avro
 
 import java.io.{File, FileNotFoundException}
 import java.nio.ByteBuffer
+import java.nio.file.{FileSystems, Files}
 import java.sql.Timestamp
 import java.util.UUID
 
@@ -462,6 +463,26 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
 
       df.write.avro(tempSaveDir)
       val newDf = sqlContext.read.avro(tempSaveDir)
+      assert(newDf.count == 8)
+    }
+  }
+
+  test("test load with non-Avro file") {
+    // Test if load works as expected
+    TestUtils.withTempDir { tempDir =>
+      val df = sqlContext.read.avro(episodesFile)
+      assert(df.count == 8)
+
+      val tempSaveDir = s"$tempDir/save/"
+      df.write.avro(tempSaveDir)
+
+      Files.createFile(new File(tempSaveDir, "non-avro").toPath)
+
+      val newDf = sqlContext
+        .read
+        .option(DefaultSource.IgnoreFilesWithoutExtensionProperty, "true")
+        .avro(tempSaveDir)
+
       assert(newDf.count == 8)
     }
   }


### PR DESCRIPTION
This PR fixes issue #136 by checking Hadoop configuration "avro.mapred.ignore.inputs.without.extension" in `DefaultSource.buildReader()`, so that files whose paths don't end with ".avro" are ignored.