### PR TITLE
Makes SerializableConfiguration.log @transient and lazy

### DIFF
--- a/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
@@ -16,7 +16,7 @@
 
 package com.databricks.spark.avro
 
-import java.io.{FileNotFoundException, IOException, ObjectInputStream, ObjectOutputStream}
+import java.io._
 import java.net.URI
 import java.util.zip.Deflater
 
@@ -209,7 +209,7 @@ private[avro] object DefaultSource {
   val IgnoreFilesWithoutExtensionProperty = "avro.mapred.ignore.inputs.without.extension"
 
   class SerializableConfiguration(@transient var value: Configuration) extends Serializable {
-    @transient private lazy val log = LoggerFactory.getLogger(getClass)
+    @transient private[avro] lazy val log = LoggerFactory.getLogger(getClass)
 
     private def writeObject(out: ObjectOutputStream): Unit = tryOrIOException {
       out.defaultWriteObject()

--- a/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
@@ -209,7 +209,7 @@ private[avro] object DefaultSource {
   val IgnoreFilesWithoutExtensionProperty = "avro.mapred.ignore.inputs.without.extension"
 
   class SerializableConfiguration(@transient var value: Configuration) extends Serializable {
-    private val log = LoggerFactory.getLogger(getClass)
+    @transient private lazy val log = LoggerFactory.getLogger(getClass)
 
     private def writeObject(out: ObjectOutputStream): Unit = tryOrIOException {
       out.defaultWriteObject()


### PR DESCRIPTION
The `log` field in `DefaultSource.SerializableConfiguration` wasn't properly handled during de/serialization. Thus, once deserialized at executor side, the `log` field becomes null and may trigger NPE. This PR fixes this issue by making the `log` field `@transient` and `lazy`.