### PR TITLE
Build against official release of Spark 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,14 @@ cache:
     - $HOME/.ivy2
 matrix:
   include:
-    # Spark 2.0.0-SNAPSHOT and Scala 2.11
+    # Spark 2.0.0 and Scala 2.11
     - jdk: openjdk7
       scala: 2.11.7
-      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.0.0-SNAPSHOT"
-    # Spark 2.0.0-SNAPSHOT and Scala 2.10
+      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.0.0"
+    # Spark 2.0.0 and Scala 2.10
     - jdk: openjdk7
       scala: 2.10.4
-      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.0.0-SNAPSHOT"
+      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.0.0"
 script:
   - sbt -Dhadoop.testVersion=$TEST_HADOOP_VERSION -Dspark.testVersion=$TEST_SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test
   - sbt ++$TRAVIS_SCALA_VERSION scalastyle

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ crossScalaVersions := Seq("2.10.5", "2.11.7")
 
 spName := "databricks/spark-avro"
 
-sparkVersion := "2.0.0-SNAPSHOT"
+sparkVersion := "2.0.0"
 
 val testSparkVersion = settingKey[String]("The version of Spark to test against.")
 
@@ -25,9 +25,6 @@ spIncludeMaven := true
 spIgnoreProvided := true
 
 sparkComponents := Seq("sql")
-
-// TODO: remove after Spark 2.0.0 is released:
-resolvers += "apache-snapshots" at "https://repository.apache.org/snapshots/"
 
 libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-api" % "1.7.5",


### PR DESCRIPTION
This patch updates the build so that we compile against the final Spark 2.0.0 release (instead of a SNAPSHOT).