### PR TITLE
Fix Kryo-serializability of SerializableConfiguration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,8 @@ libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-api" % "1.7.5",
   "org.apache.avro" % "avro" % "1.7.6" exclude("org.mortbay.jetty", "servlet-api"),
   "org.apache.avro" % "avro-mapred" % "1.7.7"  % "provided" classifier("hadoop2") exclude("org.mortbay.jetty", "servlet-api"),
+  // Kryo is provided by Spark, but we need this here in order to be able to import the @DefaultSerializer annotation:
+  "com.esotericsoftware" % "kryo-shaded" % "3.0.3" % "provided",
   "org.scalatest" %% "scalatest" % "2.2.1" % "test",
   "commons-io" % "commons-io" % "2.4" % "test"
 )

--- a/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
@@ -23,6 +23,8 @@ import java.util.zip.Deflater
 import scala.util.control.NonFatal
 
 import com.databricks.spark.avro.DefaultSource.{IgnoreFilesWithoutExtensionProperty, SerializableConfiguration}
+import com.esotericsoftware.kryo.DefaultSerializer
+import com.esotericsoftware.kryo.serializers.{JavaSerializer => KryoJavaSerializer}
 import org.apache.avro.SchemaBuilder
 import org.apache.avro.file.{DataFileConstants, DataFileReader}
 import org.apache.avro.generic.{GenericDatumReader, GenericRecord}
@@ -208,6 +210,7 @@ private[avro] class DefaultSource extends FileFormat with DataSourceRegister {
 private[avro] object DefaultSource {
   val IgnoreFilesWithoutExtensionProperty = "avro.mapred.ignore.inputs.without.extension"
 
+  @DefaultSerializer(classOf[KryoJavaSerializer])
   class SerializableConfiguration(@transient var value: Configuration) extends Serializable {
     @transient private[avro] lazy val log = LoggerFactory.getLogger(getClass)
 

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -486,24 +486,4 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
       assert(newDf.count == 8)
     }
   }
-
-  test("#139: deserializing SerializableConfiguration") {
-    import DefaultSource.SerializableConfiguration
-
-    val conf = new SerializableConfiguration(sqlContext.sparkContext.hadoopConfiguration)
-
-    val byteArrayOutputStream = new ByteArrayOutputStream()
-    val objectOutputStream = new ObjectOutputStream(byteArrayOutputStream)
-    objectOutputStream.writeObject(conf)
-
-    val bytes = byteArrayOutputStream.toByteArray
-    val byteArrayInputStream = new ByteArrayInputStream(bytes)
-    val objectInputStream = new ObjectInputStream(byteArrayInputStream)
-
-    objectInputStream.readObject() match {
-      case c: DefaultSource.SerializableConfiguration => assert(c.log != null)
-      case other => fail(
-        s"Expecting ${classOf[SerializableConfiguration]}, but got ${other.getClass}.")
-    }
-  }
 }

--- a/src/test/scala/com/databricks/spark/avro/SerializableConfigurationSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/SerializableConfigurationSuite.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.spark.avro
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.SparkConf
+import org.apache.spark.serializer.{JavaSerializer, KryoSerializer, SerializerInstance}
+import org.scalatest.FunSuite
+
+
+class SerializableConfigurationSuite extends FunSuite {
+
+  private def testSerialization(serializer: SerializerInstance): Unit = {
+    import DefaultSource.SerializableConfiguration
+    val conf = new SerializableConfiguration(new Configuration())
+
+    val serialized = serializer.serialize(conf)
+
+    serializer.deserialize[Any](serialized) match {
+      case c: SerializableConfiguration =>
+        assert(c.log != null, "log was null")
+        assert(c.value != null, "value was null")
+      case other => fail(
+        s"Expecting ${classOf[SerializableConfiguration]}, but got ${other.getClass}.")
+    }
+  }
+
+  test("serialization with JavaSerializer") {
+    testSerialization(new JavaSerializer(new SparkConf()).newInstance())
+  }
+
+  test("serialization with KryoSerializer") {
+    testSerialization(new KryoSerializer(new SparkConf()).newInstance())
+  }
+
+}


### PR DESCRIPTION
This library's inlined copy of `SerializableConfiguration` doesn't behave properly when serialized with Kryo, since its `readObject` and `writeObject` methods won't be invoked. In Spark's version of that class, this was handled by [registering](https://github.com/apache/spark/blob/ae226283e19ce396216c73b0ae2470efa122b65b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala#L108) the serializer with Kryo, but this library's copy did not do that, leading to NullPointerExceptions if Kryo serialization is enabled.

In order to fix this bug, this patch uses Kryo's `@DefaultSerializer` annotation to indicate that `SerializableConfiguration` should use Kryo's `JavaSerializer` instead of the default Kryo serializer.

Fixes #147.