### PR TITLE
fix #96, support user-define schema when reading avro files

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=0.13.9
+sbt.version=0.13.11

--- a/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
@@ -161,31 +161,10 @@ private[avro] class DefaultSource extends FileFormat with DataSourceRegister {
           DataFileReader.openReader(in, new GenericDatumReader[GenericRecord]())
         }
 
-        val fieldExtractors = {
-          val avroSchema = reader.getSchema
-          requiredSchema.zipWithIndex.map { case (field, index) =>
-            val avroField = Option(avroSchema.getField(field.name)).getOrElse {
-              throw new IllegalArgumentException(
-                s"""Cannot find required column ${field.name} in Avro schema:"
-                   |
-                   |${avroSchema.toString(true)}
-                 """.stripMargin
-              )
-            }
+        val rowConverter = SchemaConverters.createConverterToSQL(reader.getSchema, requiredSchema)
 
-            val converter = SchemaConverters.createConverterToSQL(avroField.schema())
-
-            (record: GenericRecord, buffer: Array[Any]) => {
-              buffer(index) = converter(record.get(avroField.pos()))
-            }
-          }
-        }
 
         new Iterator[InternalRow] {
-          private val rowBuffer = Array.fill[Any](requiredSchema.length)(null)
-
-          private val safeDataRow = new GenericRow(rowBuffer)
-
           // Used to convert `Row`s containing data columns into `InternalRow`s.
           private val encoderForDataColumns = RowEncoder(requiredSchema)
 
@@ -193,13 +172,9 @@ private[avro] class DefaultSource extends FileFormat with DataSourceRegister {
 
           override def next(): InternalRow = {
             val record = reader.next()
+            val safeDataRow = rowConverter(record).asInstanceOf[GenericRow]
 
-            var i = 0
-            while (i < requiredSchema.length) {
-              fieldExtractors(i)(record, rowBuffer)
-              i += 1
-            }
-
+            // The safeDataRow is reused, we must do a copy
             encoderForDataColumns.toRow(safeDataRow)
           }
         }

--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -25,7 +25,8 @@ import org.apache.avro.generic.{GenericData, GenericRecord}
 import org.apache.avro.{Schema, SchemaBuilder}
 import org.apache.avro.SchemaBuilder._
 import org.apache.avro.Schema.Type._
-import org.apache.spark.sql.Row
+
+import org.apache.spark.sql.catalyst.expressions.GenericRow
 import org.apache.spark.sql.types._
 
 /**
@@ -33,6 +34,8 @@ import org.apache.spark.sql.types._
  * versa.
  */
 object SchemaConverters {
+
+  class IncompatibleSchemaException(msg: String, ex: Throwable = null) extends Exception(msg, ex)
 
   case class SchemaType(dataType: DataType, nullable: Boolean)
 
@@ -87,11 +90,11 @@ object SchemaConverters {
             SchemaType(LongType, nullable = false)
           case Seq(t1, t2) if Set(t1, t2) == Set(FLOAT, DOUBLE) =>
             SchemaType(DoubleType, nullable = false)
-          case other => throw new UnsupportedOperationException(
+          case other => throw new IncompatibleSchemaException(
             s"This mix of union types is not supported (see README): $other")
         }
 
-      case other => throw new UnsupportedOperationException(s"Unsupported type $other")
+      case other => throw new IncompatibleSchemaException(s"Unsupported type $other")
     }
   }
 
@@ -119,88 +122,164 @@ object SchemaConverters {
   }
 
   /**
-   * Returns a function that is used to convert avro types to their
-   * corresponding sparkSQL representations.
+   * Returns a converter function to convert row in avro format to GenericRow of catalyst.
+   *
+   * @param sourceAvroSchema Source schema before conversion inferred from avro file by passed in
+   *                       by user.
+   * @param targetSqlType Target catalyst sql type after the conversion.
+   * @return returns a converter function to convert row in avro format to GenericRow of catalyst.
    */
-  private[avro] def createConverterToSQL(schema: Schema): Any => Any = {
-    schema.getType match {
-      // Avro strings are in Utf8, so we have to call toString on them
-      case STRING | ENUM => (item: Any) => if (item == null) null else item.toString
-      case INT | BOOLEAN | DOUBLE | FLOAT | LONG => identity
-      // Byte arrays are reused by avro, so we have to make a copy of them.
-      case FIXED => (item: Any) => if (item == null) {
-        null
-      } else {
-        item.asInstanceOf[Fixed].bytes().clone()
-      }
-      case BYTES => (item: Any) => if (item == null) {
-        null
-      } else {
-        val bytes = item.asInstanceOf[ByteBuffer]
-        val javaBytes = new Array[Byte](bytes.remaining)
-        bytes.get(javaBytes)
-        javaBytes
-      }
-      case RECORD =>
-        val fieldConverters = schema.getFields.map(f => createConverterToSQL(f.schema))
-        (item: Any) => if (item == null) {
-          null
-        } else {
-          val record = item.asInstanceOf[GenericRecord]
-          val converted = new Array[Any](fieldConverters.size)
-          var idx = 0
-          while (idx < fieldConverters.size) {
-            converted(idx) = fieldConverters.apply(idx)(record.get(idx))
-            idx += 1
+  def createConverterToSQL(sourceAvroSchema: Schema, targetSqlType: DataType): AnyRef => AnyRef = {
+
+    def createConverter(avroSchema: Schema,
+        sqlType: DataType, path: List[String]): AnyRef => AnyRef = {
+      val avroType = avroSchema.getType
+      (sqlType, avroType) match {
+        // Avro strings are in Utf8, so we have to call toString on them
+        case (StringType, STRING) | (StringType, ENUM) =>
+          (item: AnyRef) => if (item == null) null else item.toString
+        // Byte arrays are reused by avro, so we have to make a copy of them.
+        case (IntegerType, INT) | (BooleanType, BOOLEAN) | (DoubleType, DOUBLE) |
+             (FloatType, FLOAT) | (LongType, LONG) =>
+          identity
+        case (BinaryType, FIXED) =>
+          (item: AnyRef) =>
+            if (item == null) {
+              null
+            } else {
+              item.asInstanceOf[Fixed].bytes().clone()
+            }
+        case (BinaryType, BYTES) =>
+          (item: AnyRef) =>
+            if (item == null) {
+              null
+            } else {
+              val byteBuffer = item.asInstanceOf[ByteBuffer]
+              val bytes = new Array[Byte](byteBuffer.remaining)
+              byteBuffer.get(bytes)
+              bytes
+            }
+
+        case (struct: StructType, RECORD) =>
+          val length = struct.fields.length
+          val converters = new Array[AnyRef => AnyRef](length)
+          val avroFieldIndexes = new Array[Int](length)
+          var i = 0
+          while (i < length) {
+            val sqlField = struct.fields(i)
+            val avroField = avroSchema.getField(sqlField.name)
+            if (avroField != null) {
+              val converter = createConverter(avroField.schema(), sqlField.dataType,
+                path :+ sqlField.name)
+              converters(i) = converter
+              avroFieldIndexes(i) = avroField.pos()
+            } else if (!sqlField.nullable) {
+              throw new IncompatibleSchemaException(
+                s"Cannot find non-nullable field ${sqlField.name} at path ${path.mkString(".")} " +
+                  "in Avro schema\n" +
+                  s"Source Avro schema: $sourceAvroSchema.\n" +
+                  s"Target Catalyst type: $targetSqlType")
+            }
+            i += 1
           }
-          Row.fromSeq(converted.toSeq)
-        }
-      case ARRAY =>
-        val elementConverter = createConverterToSQL(schema.getElementType)
-        (item: Any) => if (item == null) {
-          null
-        } else {
-          item.asInstanceOf[GenericData.Array[Any]].map(elementConverter)
-        }
-      case MAP =>
-        val valueConverter = createConverterToSQL(schema.getValueType)
-        (item: Any) => if (item == null) {
-          null
-        } else {
-          item.asInstanceOf[HashMap[Any, Any]].map(x => (x._1.toString, valueConverter(x._2))).toMap
-        }
-      case UNION =>
-        if (schema.getTypes.exists(_.getType == NULL)) {
-          val remainingUnionTypes = schema.getTypes.filterNot(_.getType == NULL)
-          if (remainingUnionTypes.size == 1) {
-            createConverterToSQL(remainingUnionTypes.get(0))
-          } else {
-            createConverterToSQL(Schema.createUnion(remainingUnionTypes))
+
+          (item: AnyRef) => {
+            if (item == null) {
+              null
+            } else {
+              val record = item.asInstanceOf[GenericRecord]
+
+              val result = new Array[Any](length)
+              var i = 0
+              while (i < converters.length) {
+                if (converters(i) != null) {
+                  val converter = converters(i)
+                  result(i) = converter(record.get(avroFieldIndexes(i)))
+                }
+                i += 1
+              }
+              new GenericRow(result)
+            }
           }
-        } else schema.getTypes.map(_.getType) match {
-          case Seq(t1) =>
-            createConverterToSQL(schema.getTypes.get(0))
-          case Seq(t1, t2) if Set(t1, t2) == Set(INT, LONG) =>
-            (item: Any) => {
-              item match {
-                case l: Long => l
-                case i: Int => i.toLong
-                case null => null
+        case (arrayType: ArrayType, ARRAY) =>
+          val elementConverter = createConverter(avroSchema.getElementType, arrayType.elementType,
+            path)
+          val allowsNull = arrayType.containsNull
+          (item: AnyRef) => {
+            if (item == null) {
+              null
+            } else {
+              val array = item.asInstanceOf[GenericData.Array[AnyRef]]
+
+              array.map { element =>
+                if (element == null && !allowsNull) {
+                  throw new RuntimeException(s"Array value at path ${path.mkString(".")} is not " +
+                    "allowed to be null")
+                } else {
+                  elementConverter(element)
+                }
               }
             }
-          case Seq(t1, t2) if Set(t1, t2) == Set(FLOAT, DOUBLE) =>
-            (item: Any) => {
-              item match {
-                case d: Double => d
-                case f: Float => f.toDouble
-                case null => null
-              }
+          }
+        case (mapType: MapType, MAP) if mapType.keyType == StringType =>
+          val valueConverter = createConverter(avroSchema.getValueType, mapType.valueType, path)
+          val allowsNull = mapType.valueContainsNull
+          (item: AnyRef) => {
+            if (item == null) {
+              null
+            } else {
+              item.asInstanceOf[HashMap[AnyRef, AnyRef]].map { x =>
+                if (x._2 == null && !allowsNull) {
+                  throw new RuntimeException(s"Map value at path ${path.mkString(".")} is not " +
+                    "allowed to be null")
+                } else {
+                  (x._1.toString, valueConverter(x._2))
+                }
+              }.toMap
             }
-          case other => throw new UnsupportedOperationException(
-            s"This mix of union types is not supported (see README): $other")
-        }
-      case other => throw new UnsupportedOperationException(s"invalid avro type: $other")
+          }
+        case (sqlType, UNION) =>
+          if (avroSchema.getTypes.exists(_.getType == NULL)) {
+            val remainingUnionTypes = avroSchema.getTypes.filterNot(_.getType == NULL)
+            if (remainingUnionTypes.size == 1) {
+              createConverter(remainingUnionTypes.get(0), sqlType, path)
+            } else {
+              createConverter(Schema.createUnion(remainingUnionTypes), sqlType, path)
+            }
+          } else avroSchema.getTypes.map(_.getType) match {
+            case Seq(t1) => createConverter(avroSchema.getTypes.get(0), sqlType, path)
+            case Seq(a, b) if Set(a, b) == Set(INT, LONG) && sqlType == LongType =>
+              (item: AnyRef) => {
+                item match {
+                  case null => null
+                  case l: java.lang.Long => l
+                  case i: java.lang.Integer => new java.lang.Long(i.longValue())
+                }
+              }
+            case Seq(a, b) if Set(a, b) == Set(FLOAT, DOUBLE) && sqlType == DoubleType =>
+              (item: AnyRef) => {
+                item match {
+                  case null => null
+                  case d: java.lang.Double => d
+                  case f: java.lang.Float => new java.lang.Double(f.doubleValue())
+                }
+              }
+            case other => throw new IncompatibleSchemaException(
+              s"Cannot convert Avro schema to catalyst type because schema at path " +
+                s"${path.mkString(".")} is not compatible (avroType = $other, sqlType = $sqlType)" +
+                s" or this mix of union types is not supported (see README):\n" +
+                s"Source Avro schema: $sourceAvroSchema.\n" +
+                s"Target Catalyst type: $targetSqlType")
+          }
+        case (left, right) =>
+          throw new IncompatibleSchemaException(
+            s"Cannot convert Avro schema to catalyst type because schema at path " +
+              s"${path.mkString(".")} is not compatible (avroType = $left, sqlType = $right). \n" +
+              s"Source Avro schema: $sourceAvroSchema.\n" +
+              s"Target Catalyst type: $targetSqlType")
+      }
     }
+    createConverter(sourceAvroSchema, targetSqlType, List.empty[String])
   }
 
   /**
@@ -241,7 +320,7 @@ object SchemaConverters {
           schemaBuilder.record(structName).namespace(recordNamespace),
           recordNamespace)
 
-      case other => throw new IllegalArgumentException(s"Unexpected type $dataType.")
+      case other => throw new IncompatibleSchemaException(s"Unexpected type $dataType.")
     }
   }
 
@@ -284,7 +363,7 @@ object SchemaConverters {
           newFieldBuilder.record(structName).namespace(recordNamespace),
           recordNamespace)
 
-      case other => throw new UnsupportedOperationException(s"Unexpected type $dataType.")
+      case other => throw new IncompatibleSchemaException(s"Unexpected type $dataType.")
     }
   }
 


### PR DESCRIPTION
With this PR, we can specify a user-provided custom schema when reading avro files. The custom schema can contain non-existing fields.
 
1. If the custom schema contains non-existing field and the field is nullable, then we will fill the value as null. The non-existing fields can exists as top level columns, or nested columns.
2. If the custom schema contains non-existing field and the field is NOT nullable, then we will throw an exception.
3. If the custom schema is a subset of the avro file schema, then we will only retrieve the fields defined in custom schema.

**Example:**
```
scala> val df = Seq((1,2,3)).toDF("a", "b", "c")
scala> df.write.format("com.databricks.spark.avro").save("/tmp/output")
scala> import org.apache.spark.sql.types._

// Prepare a customized schema
scala> val struct = StructType(StructField("a", IntegerType, true) :: StructField("non_exist", IntegerType, true) :: Nil)
scala> spark.read.format("com.databricks.spark.avro").schema(struct).load("/tmp/output").show()
+---+---------+
|  a|non_exist|
+---+---------+
|  1|     null|
+---+---------+

// Save the schema to a Json string, you can later save this to a file.
scala> val jsonSchema = struct.json
jsonSchema: String = {"type":"struct","fields":[{"name":"a","type":"integer","nullable":true,"metadata":{}},{"name":"non_exist","type":"integer","nullable":true,"metadata":{}}]}

// Load the Json string back
scala> spark.read.format("com.databricks.spark.avro").schema(DataType.fromJson(jsonSchema).asInstanceOf[StructType]).load("/tmp/output").show()
+---+---------+
|  a|non_exist|
+---+---------+
|  1|     null|
+---+---------+
```

Fix #96