### PR TITLE
Fix #157, replace deprecated SqlContext with SparkSession

### DIFF
--- a/src/test/scala/com/databricks/spark/avro/AvroReadBenchmark.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroReadBenchmark.scala
@@ -19,8 +19,7 @@ package com.databricks.spark.avro
 import java.io.File
 import java.util.concurrent.TimeUnit
 
-import org.apache.spark.SparkContext
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.SparkSession
 
 
 /**
@@ -37,14 +36,15 @@ object AvroReadBenchmark {
         "is empty. First you should generate some files to run a benchmark with (see README)")
     }
 
-    val sqlContext = new SQLContext(new SparkContext("local[2]", "AvroReadBenchmark"))
+    val spark = SparkSession.builder().master("local[2]").appName("AvroReadBenchmark")
+      .getOrCreate()
 
-    sqlContext.read.avro(AvroFileGenerator.outputDir).count()
+    spark.read.avro(AvroFileGenerator.outputDir).count()
 
     println("\n\n\nStaring benchmark test - creating DataFrame from benchmark avro files\n\n\n")
 
     val startTime = System.nanoTime
-    sqlContext
+    spark
       .read
       .avro(AvroFileGenerator.outputDir)
       .select("string")
@@ -54,6 +54,6 @@ object AvroReadBenchmark {
 
     println(s"\n\n\nFinished benchmark test - result was $executionTime seconds\n\n\n")
 
-    sqlContext.sparkContext.stop()  // Otherwise scary exception message appears
+    spark.sparkContext.stop()  // Otherwise scary exception message appears
   }
 }

--- a/src/test/scala/com/databricks/spark/avro/AvroWriteBenchmark.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroWriteBenchmark.scala
@@ -23,8 +23,8 @@ import scala.util.Random
 
 import com.google.common.io.Files
 import org.apache.commons.io.FileUtils
-import org.apache.spark.SparkContext
-import org.apache.spark.sql.{SQLContext, Row}
+
+import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.types._
 
 /**
@@ -61,12 +61,13 @@ object AvroWriteBenchmark {
 
     println(s"\n\n\nPreparing for a benchmark test - creating a RDD with $numberOfRows rows\n\n\n")
 
-    val sqlContext = new SQLContext(new SparkContext("local[2]", "AvroReadBenchmark"))
+    val spark = SparkSession.builder().master("local[2]").appName("AvroReadBenchmark")
+      .getOrCreate()
 
     val tempDir = Files.createTempDir()
     val avroDir = tempDir + "/avro"
-    val testDataFrame = sqlContext.createDataFrame(
-      sqlContext.sparkContext.parallelize(0 until numberOfRows).map(_ => generateRandomRow()),
+    val testDataFrame = spark.createDataFrame(
+      spark.sparkContext.parallelize(0 until numberOfRows).map(_ => generateRandomRow()),
       testSchema)
 
     println("\n\n\nStaring benchmark test - writing a DataFrame as avro file\n\n\n")
@@ -81,6 +82,6 @@ object AvroWriteBenchmark {
     println(s"\n\n\nFinished benchmark test - result was $executionTime seconds\n\n\n")
 
     FileUtils.deleteDirectory(tempDir)
-    sqlContext.sparkContext.stop()  // Otherwise scary exception message appears
+    spark.sparkContext.stop()  // Otherwise scary exception message appears
   }
 }

--- a/src/test/scala/com/databricks/spark/avro/TestUtils.scala
+++ b/src/test/scala/com/databricks/spark/avro/TestUtils.scala
@@ -16,7 +16,7 @@
 
 package com.databricks.spark.avro
 
-import java.io.{IOException, File}
+import java.io.{File, IOException}
 import java.nio.ByteBuffer
 import java.util
 
@@ -25,7 +25,8 @@ import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 
 import com.google.common.io.Files
-import org.apache.spark.sql.SQLContext
+
+import org.apache.spark.sql.SparkSession
 
 private[avro] object TestUtils {
 
@@ -33,7 +34,7 @@ private[avro] object TestUtils {
    * This function checks that all records in a file match the original
    * record.
    */
-  def checkReloadMatchesSaved(sqlContext: SQLContext, testFile: String, avroDir: String) = {
+  def checkReloadMatchesSaved(spark: SparkSession, testFile: String, avroDir: String) = {
 
     def convertToString(elem: Any): String = {
       elem match {
@@ -45,8 +46,8 @@ private[avro] object TestUtils {
       }
     }
 
-    val originalEntries = sqlContext.read.avro(testFile).collect()
-    val newEntries = sqlContext.read.avro(avroDir).collect()
+    val originalEntries = spark.read.avro(testFile).collect()
+    val newEntries = spark.read.avro(avroDir).collect()
 
     assert(originalEntries.length == newEntries.length)
 


### PR DESCRIPTION
This PR replaces deprecated SqlContext with class SparkSession.

Fix #157