### PR TITLE
Support user defined avro json format schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,21 @@ val df = spark.read
 df.filter("doctor > 5").write.format("com.databricks.spark.avro").save("/tmp/output")
 ```
 
+You can specify a custom Avro schema:
+
+```scala
+import org.apache.avro.Schema
+import org.apache.spark.sql.SparkSession
+
+val schema = new Schema.Parser().parse(new File("user.avsc"))
+val spark = SparkSession.builder().master("local").getOrCreate()
+spark
+  .read
+  .format("com.databricks.spark.avro")
+  .option("avroSchema", schema.toString)
+  .load("src/test/resources/episodes.avro").show()
+```
+
 You can also specify Avro compression options:
 
 ```scala

--- a/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
@@ -22,7 +22,7 @@ import java.util.zip.Deflater
 
 import scala.util.control.NonFatal
 
-import com.databricks.spark.avro.DefaultSource.{AVRO_SCHEMA, IgnoreFilesWithoutExtensionProperty, SerializableConfiguration}
+import com.databricks.spark.avro.DefaultSource.{AvroSchema, IgnoreFilesWithoutExtensionProperty, SerializableConfiguration}
 import com.esotericsoftware.kryo.DefaultSerializer
 import com.esotericsoftware.kryo.serializers.{JavaSerializer => KryoJavaSerializer}
 import org.apache.avro.{Schema, SchemaBuilder}
@@ -73,17 +73,7 @@ private[avro] class DefaultSource extends FileFormat with DataSourceRegister {
     }
 
     // User can specify an optional avro json schema.
-    // For example:
-    // {{{
-    //   val schema = new Schema.Parser().parse(new File("user.avsc"))
-    //   val spark = SparkSession.builder().master("local").getOrCreate()
-    //   spark
-    //     .read
-    //     .format("com.databricks.spark.avro")
-    //     .option(DefaultSource.AVRO_SCHEMA, schema.toString)
-    //     .load("/tmp/avro_file_path").show()
-    // }}}
-    val avroSchema = options.get(AVRO_SCHEMA).map(new Schema.Parser().parse).getOrElse {
+    val avroSchema = options.get(AvroSchema).map(new Schema.Parser().parse).getOrElse {
       val in = new FsInput(sampleFile.getPath, conf)
       val reader = DataFileReader.openReader(in, new GenericDatumReader[GenericRecord]())
       reader.getSchema
@@ -221,7 +211,7 @@ private[avro] class DefaultSource extends FileFormat with DataSourceRegister {
 private[avro] object DefaultSource {
   val IgnoreFilesWithoutExtensionProperty = "avro.mapred.ignore.inputs.without.extension"
 
-  val AVRO_SCHEMA = "avroSchema"
+  val AvroSchema = "avroSchema"
 
   @DefaultSerializer(classOf[KryoJavaSerializer])
   class SerializableConfiguration(@transient var value: Configuration) extends Serializable {

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -395,6 +395,24 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
     assert(e2.length == 8)
   }
 
+  test("support user provided avro schema") {
+    val avroSchema =
+      """
+        |{
+        |  "type" : "record",
+        |  "name" : "test_schema",
+        |  "fields" : [{
+        |    "name" : "string",
+        |    "type" : "string",
+        |    "doc"  : "Meaningless string of characters"
+        |  }]
+        |}
+      """.stripMargin
+    val result = spark.read.option(DefaultSource.AVRO_SCHEMA, avroSchema).avro(testFile).collect()
+    val expected = spark.read.avro(testFile).select("string").collect()
+    assert(result.sameElements(expected))
+  }
+
   test("reading from invalid path throws exception") {
 
     // Directory given has no avro files

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -408,7 +408,7 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
         |  }]
         |}
       """.stripMargin
-    val result = spark.read.option(DefaultSource.AVRO_SCHEMA, avroSchema).avro(testFile).collect()
+    val result = spark.read.option(DefaultSource.AvroSchema, avroSchema).avro(testFile).collect()
     val expected = spark.read.avro(testFile).select("string").collect()
     assert(result.sameElements(expected))
   }


### PR DESCRIPTION
This PR allows user to specify a custom avro schema in options when reading avro files:

For example:

```scala
import org.apache.avro.Schema
import org.apache.spark.sql.SparkSession

val schema = new Schema.Parser().parse(new File("user.avsc"))
val spark = SparkSession.builder().master("local").getOrCreate()
spark
  .read
  .format("com.databricks.spark.avro")
  .option("avroSchema", schema.toString)
  .load("src/test/resources/episodes.avro").show()
```
Fix #160