### PR TITLE
First Record in Partition is lost in AvroUtil.convertRowRDDToRecordRDD 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ target/
 .idea/
 .idea_modules/
 *.iml
+.cache-main
+.cache-tests
+.classpath
+.project
+.settings/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+
+Applied patches (more or less exact): 
+
+https://github.com/databricks/spark-avro/pull/117  : support for (more) complex unions (still limited though)
+https://github.com/databricks/spark-avro/pull/89 : GenericRecord to Row conversion
+https://github.com/databricks/spark-avro/pull/132/files : expose the convertor
+https://github.com/databricks/spark-avro/pull/130 : fixes for ARRAY conversion
+https://github.com/databricks/spark-avro/pull/73 : uses namespaces before structs
+
+Disclaimer: this is work in progress, it's a temporary series of fixes and extensions while waiting for spark-2.0 and the dataset API. 
+
+
+
 # Avro Data Source for Apache Spark
 
 A library for reading and writing Avro data from [Spark SQL](http://spark.apache.org/docs/latest/sql-programming-guide.html).

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ crossScalaVersions := Seq("2.10.6", "2.11.8")
 
 spName := "databricks/spark-avro"
 
-sparkVersion := "1.6.1"
+sparkVersion := "1.6.2"
 
 val testSparkVersion = settingKey[String]("The version of Spark to test against.")
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "spark-avro"
 
 organization := "com.databricks"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.10.6"
 
 crossScalaVersions := Seq("2.10.6", "2.11.8")
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,13 +2,13 @@ name := "spark-avro"
 
 organization := "com.databricks"
 
-scalaVersion := "2.10.5"
+scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq("2.10.5", "2.11.7")
+crossScalaVersions := Seq("2.10.6", "2.11.8")
 
 spName := "databricks/spark-avro"
 
-sparkVersion := "1.4.1"
+sparkVersion := "1.6.1"
 
 val testSparkVersion = settingKey[String]("The version of Spark to test against.")
 
@@ -27,8 +27,8 @@ spIgnoreProvided := true
 sparkComponents := Seq("sql")
 
 libraryDependencies ++= Seq(
-  "org.apache.avro" % "avro" % "1.7.6" exclude("org.mortbay.jetty", "servlet-api"),
-  "org.apache.avro" % "avro-mapred" % "1.7.7"  % "provided" classifier("hadoop2") exclude("org.mortbay.jetty", "servlet-api"),
+  "org.apache.avro" % "avro" % "1.8.1" exclude("org.mortbay.jetty", "servlet-api"),
+  "org.apache.avro" % "avro-mapred" % "1.8.1"  % "provided" classifier("hadoop2") exclude("org.mortbay.jetty", "servlet-api"),
   "org.scalatest" %% "scalatest" % "2.2.1" % "test",
   "commons-io" % "commons-io" % "2.4" % "test"
 )
@@ -59,47 +59,4 @@ releaseCrossBuild := true
 
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
 
-releasePublishArtifactsAction := PgpKeys.publishSigned.value
 
-pomExtra :=
-  <url>https://github.com/databricks/spark-avro</url>
-  <scm>
-    <url>git@github.com:databricks/spark-avro.git</url>
-    <connection>scm:git:git@github.com:databricks/spark-avro.git</connection>
-  </scm>
-  <developers>
-    <developer>
-      <id>marmbrus</id>
-      <name>Michael Armbrust</name>
-      <url>https://github.com/marmbrus</url>
-    </developer>
-    <developer>
-      <id>JoshRosen</id>
-      <name>Josh Rosen</name>
-      <url>https://github.com/JoshRosen</url>
-    </developer>
-    <developer>
-      <id>vlyubin</id>
-      <name>Volodymyr Lyubinets</name>
-      <url>https://github.com/vlyubin</url>
-    </developer>
-  </developers>
-
-bintrayReleaseOnPublish in ThisBuild := false
-
-import ReleaseTransformations._
-
-// Add publishing to spark packages as another step.
-releaseProcess := Seq[ReleaseStep](
-  checkSnapshotDependencies,
-  inquireVersions,
-  runTest,
-  setReleaseVersion,
-  commitReleaseVersion,
-  tagRelease,
-  publishArtifacts,
-  setNextVersion,
-  commitNextVersion,
-  pushChanges,
-  releaseStepTask(spPublish)
-)

--- a/src/main/scala/com/databricks/spark/avro/AvroRelation.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroRelation.scala
@@ -117,71 +117,16 @@ private[avro] class AvroRelation(
       sqlContext.sparkContext.emptyRDD[Row]
     } else {
       new UnionRDD[Row](sqlContext.sparkContext,
-      inputs.map(path =>
-        sqlContext.sparkContext.hadoopFile(
+      inputs.map(path => {
+        val wrappedAvroRDD = sqlContext.sparkContext.hadoopFile(
           path.getPath.toString,
           classOf[org.apache.avro.mapred.AvroInputFormat[GenericRecord]],
           classOf[org.apache.avro.mapred.AvroWrapper[GenericRecord]],
-          classOf[org.apache.hadoop.io.NullWritable]).keys.map(_.datum())
-          .mapPartitions { records =>
-            if (records.isEmpty) {
-              Iterator.empty
-            } else {
-              val firstRecord = records.next()
-              val superSchema = firstRecord.getSchema // the schema of the actual record
-              // the fields that are actually required along with their converters
-              val avroFieldMap = superSchema.getFields.map(f => (f.name, f)).toMap
-
-              new Iterator[Row] {
-                private[this] val baseIterator = records
-                private[this] var currentRecord = firstRecord
-                private[this] val rowBuffer = new Array[Any](requiredColumns.length)
-                // A micro optimization to avoid allocating a WrappedArray per row.
-                private[this] val bufferSeq = rowBuffer.toSeq
-
-                // An array of functions that pull a column out of an avro record and puts the
-                // converted value into the correct slot of the rowBuffer.
-                private[this] val fieldExtractors = requiredColumns.zipWithIndex.map {
-                  case (columnName, idx) =>
-                    // Spark SQL should not pass us invalid columns
-                    val field =
-                      avroFieldMap.getOrElse(
-                        columnName,
-                        throw new AssertionError(s"Invalid column $columnName"))
-                    val converter = SchemaConverters.createConverterToSQL(field.schema)
-
-                    (record: GenericRecord) => rowBuffer(idx) = converter(record.get(field.pos()))
-                }
-
-                private def advanceNextRecord() = {
-                  if (baseIterator.hasNext) {
-                    currentRecord = baseIterator.next()
-                    true
-                  } else {
-                    false
-                  }
-                }
-
-                def hasNext = {
-                  currentRecord != null || advanceNextRecord()
-                }
-
-                def next() = {
-                  assert(hasNext)
-                  var i = 0
-                  while (i < fieldExtractors.length) {
-                    fieldExtractors(i)(currentRecord)
-                    i += 1
-                  }
-                  currentRecord = null
-                  Row.fromSeq(bufferSeq)
-                }
-              }
-            }
-        }))
+          classOf[org.apache.hadoop.io.NullWritable])
+        AvroUtil.convertRecordRDDToRowRDD(wrappedAvroRDD.keys.map(_.datum()), requiredColumns)
+      }))
     }
   }
-
   /**
    * Checks to see if the given Any is the same avro relation based off of the input paths, schema,
    * and partitions

--- a/src/main/scala/com/databricks/spark/avro/AvroUtil.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroUtil.scala
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2014 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.databricks.spark.avro
+
+import scala.collection.Iterator
+import scala.collection.JavaConversions._
+
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericRecord
+
+import org.apache.spark.api.java.JavaRDD
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+
+class AvroSchema(s: String) extends Serializable {
+  
+  def this(schema: Schema) = this(schema.toString())
+  
+  lazy val schema : Schema = new Schema.Parser().parse(s)
+  
+}
+
+
+object AvroUtil {
+
+  /**
+   * Create a DataFrame from an RDD of GenericRecords, with columns based on the provided schema
+   */
+  def createDataFrame(
+      sqlContext: SQLContext,
+      rdd: RDD[GenericRecord],
+      schema: Schema): DataFrame = {
+    sqlContext.createDataFrame(
+      convertRecordRDDToRowRDD(rdd, schema.getFields.map(_.name()).toArray),
+      SchemaConverters.toSqlType(schema).dataType.asInstanceOf[StructType])
+  }
+
+  /**
+   * Java API to create a DataFrame from an RDD of GenericRecords, with columns based on the
+   * provided schema.
+   */
+  def createDataFrame(
+      sqlContext: SQLContext,
+      rdd: JavaRDD[GenericRecord],
+      schema: Schema): DataFrame = {
+    createDataFrame(sqlContext, rdd.rdd, schema)
+  }
+
+  def createRdd(df: DataFrame, schema: Schema) : RDD[GenericRecord] = 
+    convertRowRDDToRecordRDD(df.rdd, new AvroSchema(schema))
+    
+  private[avro] def convertRecordRDDToRowRDD(
+      rdd: RDD[GenericRecord],
+      requiredColumns: Array[String]): RDD[Row] = {
+    rdd.mapPartitions { records =>
+      if (records.isEmpty) {
+        Iterator.empty
+      } else {
+        val firstRecord = records.next()
+        val superSchema = firstRecord.getSchema // the schema of the actual record
+        // the fields that are actually required along with their converters
+        val avroFieldMap = superSchema.getFields.map(f => (f.name, f)).toMap
+
+        new Iterator[Row] {
+          private[this] val baseIterator = records
+          private[this] var currentRecord = firstRecord
+          private[this] val rowBuffer = new Array[Any](requiredColumns.length)
+          // A micro optimization to avoid allocating a WrappedArray per row.
+          private[this] val bufferSeq = rowBuffer.toSeq
+
+          // An array of functions that pull a column out of an avro record and puts the
+          // converted value into the correct slot of the rowBuffer.
+          private[this] val fieldExtractors = requiredColumns.zipWithIndex.map {
+            case (columnName, idx) =>
+              // Spark SQL should not pass us invalid columns
+              avroFieldMap.get(columnName) match {
+                case Some(field) =>
+                  val converter = SchemaConverters.createConverterToSQL(field.schema)
+                  (record: GenericRecord) => rowBuffer(idx) = converter(record.get(field.pos()))
+                case None => (record: GenericRecord) => rowBuffer(idx) = null
+              }
+              
+              /**
+              val field =
+                avroFieldMap.getOrElse(
+                  columnName,
+                  throw new AssertionError(s"Invalid column $columnName"))
+              val converter = SchemaConverters.createConverterToSQL(field.schema)
+              (record: GenericRecord) => rowBuffer(idx) = converter(record.get(field.pos()))
+              * 
+              */
+          }
+
+          private def advanceNextRecord() = {
+            if (baseIterator.hasNext) {
+              currentRecord = baseIterator.next()
+              true
+            } else {
+              false
+            }
+          }
+
+          def hasNext = {
+            currentRecord != null || advanceNextRecord()
+          }
+
+          def next() = {
+            assert(hasNext)
+            var i = 0
+            while (i < fieldExtractors.length) {
+              fieldExtractors(i)(currentRecord)
+              i += 1
+            }
+            currentRecord = null
+            Row.fromSeq(bufferSeq)
+          }
+        }
+      }
+    }
+  }
+  
+  private[avro] def convertRowRDDToRecordRDD(
+      rdd: RDD[Row], 
+      schema: AvroSchema): RDD[GenericRecord] = {
+    rdd.mapPartitions { records =>
+      if (records.isEmpty) Iterator.empty
+      else {
+        val dataType = records.next().schema
+        val convertor = SchemaConverters.createConverterToAvro(dataType, schema)
+        records.map { x => convertor(x).asInstanceOf[GenericRecord] }
+      }
+    }
+  }
+  
+  
+  
+}

--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -145,11 +145,11 @@ object SchemaConverters {
       case ByteType | ShortType | IntegerType | LongType |
            FloatType | DoubleType | BooleanType => identity
       case StringType => {
-        // TEMP SUPPORT FOR (UNIONS OF) ENUMS OF STRINGS
+        // SUPPORT FOR (UNIONS OF) ENUMS OF STRINGS
         val elementSchema = schema.getType match {
           case UNION => {
             val remainingTypes = schema.getTypes.filterNot(_.getType == NULL)
-            if (remainingTypes.length != 1) throw new UnsupportedOperationException("Unsupported: Avro Union can only represent a SQL ArrayType if it's used for optional elements (null)")
+            if (remainingTypes.length != 1) throw new UnsupportedOperationException("Unsupported: String Union can only represent a SQL StringType if it's used for optional elements (null)")
             else {
               remainingTypes.get(0)
             }
@@ -159,9 +159,14 @@ object SchemaConverters {
         elementSchema.getType match {
           case ENUM => {
             (item: Any) => {
-              println("IT IS AN ENUM: " + item)
-              if (item == null) null
-              else new GenericData.EnumSymbol(elementSchema, item.asInstanceOf[String])
+              if (item == null) {
+                //println("IT IS A NULL ENUM: " + item)
+                null
+              }
+              else {
+                //println("WRITING ENUM: " + item)         
+                new GenericData.EnumSymbol(elementSchema, item.asInstanceOf[String])
+              }
             }
           }
           case _ => identity

--- a/src/main/scala/com/databricks/spark/avro/package.scala
+++ b/src/main/scala/com/databricks/spark/avro/package.scala
@@ -20,18 +20,23 @@ import org.apache.avro.generic.GenericRecord
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
-
+import org.apache.spark.sql.types.StructType
 
 package object avro {
 
-  /**
-   * Adds a method, `avroFile`, to SQLContext that allows reading data stored in Avro.
-   */
-  @deprecated("use read.avro()", "1.1.0")
   implicit class AvroContext(sqlContext: SQLContext) {
+    
+    @deprecated("use read.avro()", "1.1.0")
     def avroFile(filePath: String, minPartitions: Int = 0) =
       sqlContext.baseRelationToDataFrame(
         new AvroRelation(Array(filePath), None, None, Map.empty)(sqlContext))
+
+    def createAvroDataFrame(rdd: RDD[GenericRecord], schema: Schema): DataFrame = 
+      AvroUtil.createDataFrame(sqlContext, rdd, schema)
+      
+    def createAvroRdd(df: DataFrame, schema: Schema) : RDD[GenericRecord] = 
+      AvroUtil.createRdd(df, schema)     
+
   }
 
   /**
@@ -47,20 +52,28 @@ package object avro {
    * the DataFileReade
    */
   implicit class AvroDataFrameReader(reader: DataFrameReader) {
+    
     def avro: String => DataFrame = reader.format("com.databricks.spark.avro").load
+    
+    // Adds a method, `schema`, to DataFrameReader that allows you to specify avro schema, e.g.
+    //   val avroSchema = new Schema.Parser().parse(new File("avsc/user.avsc"))
+    //   val df = sqlContext.read.schema(avroSchema).avro("avro/") 
+    def schema(avroSchema: Schema): DataFrameReader = {
+     val sqlSchema = SchemaConverters.toSqlType(avroSchema).dataType.asInstanceOf[StructType]
+     reader.schema(sqlSchema)
+   }
+    
   }
   
+  /*
   implicit class AvroSQLContext(sqlContext: SQLContext) {
     
-    def createDataFrame(rdd: RDD[GenericRecord], schema: Schema): DataFrame = 
+    def createAvroDataFrame(rdd: RDD[GenericRecord], schema: Schema): DataFrame = 
       AvroUtil.createDataFrame(sqlContext, rdd, schema)
-
-    //def createDataFrame(rdd: RDD[GenericRecord]): DataFrame = 
-    //  AvroUtil.createDataFrame(sqlContext, rdd, schema)
       
-      
-    def createRdd(df: DataFrame, schema: Schema) : RDD[GenericRecord] = 
+    def createAvroRdd(df: DataFrame, schema: Schema) : RDD[GenericRecord] = 
       AvroUtil.createRdd(df, schema) 
     
-  }
+  }*/
+
 }

--- a/src/main/scala/com/databricks/spark/avro/package.scala
+++ b/src/main/scala/com/databricks/spark/avro/package.scala
@@ -15,7 +15,12 @@
  */
 package com.databricks.spark
 
-import org.apache.spark.sql.{SQLContext, DataFrameReader, DataFrameWriter, DataFrame}
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericRecord
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql._
+
 
 package object avro {
 
@@ -43,5 +48,19 @@ package object avro {
    */
   implicit class AvroDataFrameReader(reader: DataFrameReader) {
     def avro: String => DataFrame = reader.format("com.databricks.spark.avro").load
+  }
+  
+  implicit class AvroSQLContext(sqlContext: SQLContext) {
+    
+    def createDataFrame(rdd: RDD[GenericRecord], schema: Schema): DataFrame = 
+      AvroUtil.createDataFrame(sqlContext, rdd, schema)
+
+    //def createDataFrame(rdd: RDD[GenericRecord]): DataFrame = 
+    //  AvroUtil.createDataFrame(sqlContext, rdd, schema)
+      
+      
+    def createRdd(df: DataFrame, schema: Schema) : RDD[GenericRecord] = 
+      AvroUtil.createRdd(df, schema) 
+    
   }
 }

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -340,7 +340,7 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
      val record = new SerializableRecord()
      record.put("content", "abc")
      val recordRdd = sqlContext.sparkContext.parallelize(Seq[GenericRecord](record))
-     val df = sqlContext.createDataFrame(recordRdd, record.getSchema)
+     val df = sqlContext.createAvroDataFrame(recordRdd, record.getSchema)
      assert(df.count() == 1)
    }
  

--- a/src/test/scala/com/databricks/spark/avro/SerializableRecord.scala
+++ b/src/test/scala/com/databricks/spark/avro/SerializableRecord.scala
@@ -1,0 +1,43 @@
+package com.databricks.spark.avro
+
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericRecord
+
+class SerializableRecord extends GenericRecord with Serializable {
+
+  private var content: String = null
+
+  override def get(key: String): AnyRef = {
+    assert(key == "content")
+    content
+  }
+
+  override def put(key: String, v: scala.Any): Unit = {
+    assert(key == "content")
+    content = v.toString
+  }
+
+  override def get(i: Int): AnyRef = {
+    assert(i == 0)
+    content
+  }
+
+  override def put(i: Int, v: scala.Any): Unit = {
+    assert(i == 0)
+    content = v.toString
+  }
+
+  override def getSchema: Schema = {
+    val parser = new Schema.Parser()
+    parser.parse(
+      """{
+        |  "type": "record",
+        |  "name": "test_record",
+        |  "fields": [{
+        |    "name": "content",
+        |    "type": "string"
+        |  }]
+        |}
+      """.stripMargin)
+  }
+}


### PR DESCRIPTION
When RowRDD is converted to RecordRDD, the first record in every partition is lost. This is because schema is retrieved by doing records.next().schema and the rest of the records are mapped.

Here is the fix:
```scala
  private[avro] def convertRowRDDToRecordRDD(
      rdd: RDD[Row], 
      schema: AvroSchema): RDD[GenericRecord] = {
    rdd.mapPartitions { records =>
      if (records.isEmpty) Iterator.empty
      else {
        records.map { x =>
          val convertor = SchemaConverters.createConverterToAvro(x.schema, schema)
          convertor(x).asInstanceOf[GenericRecord] }
      }
    }
  }
```