### PR TITLE
Ensure that FsInput is always closed in order to prevent resource leaks

### DIFF
--- a/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
@@ -200,7 +200,7 @@ private[avro] class DefaultSource extends FileFormat with DataSourceRegister {
               false
             } else {
               val r = reader.hasNext
-              if (!r && !completed) {
+              if (!r) {
                 reader.close()
                 completed = true
               }

--- a/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
@@ -196,12 +196,16 @@ private[avro] class DefaultSource extends FileFormat with DataSourceRegister {
           private[this] var completed = false
 
           override def hasNext: Boolean = {
-            val r = reader.hasNext
-            if (!r && !completed) {
-              reader.close()
-              completed = true
+            if (completed) {
+              false
+            } else {
+              val r = reader.hasNext
+              if (!r && !completed) {
+                reader.close()
+                completed = true
+              }
+              r
             }
-            r
           }
 
           override def next(): InternalRow = {

--- a/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
@@ -35,6 +35,7 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hadoop.mapreduce.Job
 import org.slf4j.LoggerFactory
 
+import org.apache.spark.TaskContext
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
@@ -75,8 +76,16 @@ private[avro] class DefaultSource extends FileFormat with DataSourceRegister {
     // User can specify an optional avro json schema.
     val avroSchema = options.get(AvroSchema).map(new Schema.Parser().parse).getOrElse {
       val in = new FsInput(sampleFile.getPath, conf)
-      val reader = DataFileReader.openReader(in, new GenericDatumReader[GenericRecord]())
-      reader.getSchema
+      try {
+        val reader = DataFileReader.openReader(in, new GenericDatumReader[GenericRecord]())
+        try {
+          reader.getSchema
+        } finally {
+          reader.close()
+        }
+      } finally {
+        in.close()
+      }
     }
 
     SchemaConverters.toSqlType(avroSchema).dataType match {
@@ -144,6 +153,7 @@ private[avro] class DefaultSource extends FileFormat with DataSourceRegister {
       spark.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
 
     (file: PartitionedFile) => {
+      val log = LoggerFactory.getLogger(classOf[DefaultSource])
       val conf = broadcastedConf.value.value
 
       // TODO Removes this check once `FileFormat` gets a general file filtering interface method.
@@ -158,7 +168,22 @@ private[avro] class DefaultSource extends FileFormat with DataSourceRegister {
       } else {
         val reader = {
           val in = new FsInput(new Path(new URI(file.filePath)), conf)
-          DataFileReader.openReader(in, new GenericDatumReader[GenericRecord]())
+          try {
+            DataFileReader.openReader(in, new GenericDatumReader[GenericRecord]())
+          } catch {
+            case NonFatal(e) =>
+              log.error("Exception while opening DataFileReader", e)
+              in.close()
+              throw e
+          }
+        }
+
+        // Ensure that the reader is closed even if the task fails or doesn't consume the entire
+        // iterator of records.
+        Option(TaskContext.get()).foreach { taskContext =>
+          taskContext.addTaskCompletionListener { _ =>
+            reader.close()
+          }
         }
 
         val rowConverter = SchemaConverters.createConverterToSQL(reader.getSchema, requiredSchema)
@@ -168,7 +193,16 @@ private[avro] class DefaultSource extends FileFormat with DataSourceRegister {
           // Used to convert `Row`s containing data columns into `InternalRow`s.
           private val encoderForDataColumns = RowEncoder(requiredSchema)
 
-          override def hasNext: Boolean = reader.hasNext
+          private[this] var completed = false
+
+          override def hasNext: Boolean = {
+            val r = reader.hasNext
+            if (!r && !completed) {
+              reader.close()
+              completed = true
+            }
+            r
+          }
 
           override def next(): InternalRow = {
             val record = reader.next()


### PR DESCRIPTION
There are two places where `FsInput`s are opened but never closed, leading to connection / resource leaks and causing hangs (such as the one reported in #156).

This patch addresses this issue by adding logic to ensure that these inputs are closed under all circumstances, including error-cases.

I managed to reproduce #156 in `spark-shell` and have verified that this fixes the hang.

Fixes #156.