### PR TITLE
Fix ClassCastException when deserializing Map field

### DIFF
--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -16,7 +16,6 @@
 package com.databricks.spark.avro
 
 import java.nio.ByteBuffer
-import java.util.HashMap
 
 import scala.collection.JavaConversions._
 
@@ -228,7 +227,7 @@ object SchemaConverters {
             if (item == null) {
               null
             } else {
-              item.asInstanceOf[HashMap[AnyRef, AnyRef]].map { x =>
+              item.asInstanceOf[java.util.Map[AnyRef, AnyRef]].map { x =>
                 if (x._2 == null && !allowsNull) {
                   throw new RuntimeException(s"Map value at path ${path.mkString(".")} is not " +
                     "allowed to be null")


### PR DESCRIPTION
My Avro object has a field defined as java.util.Map.  In that case, item ends up being an instance of MapWrapper, which cannot be cast to a HashMap.  Casting to Map works fine, and presumably would still work in any case that you could cast to a HashMap.  I see nothing here that would specifically require the HashMap implementation.