### PR TITLE
Bump SBT plugin versions; update Travis command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: scala
 sudo: false
+# Cache settings here are based on latest SBT documentation.
 cache:
   directories:
-    - $HOME/.ivy2
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/
+before_cache:
+  # Tricks to avoid unnecessary cache updates
+  - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
+  - find $HOME/.sbt -name "*.lock" -delete
 matrix:
   include:
     # Spark 2.0.0 and Scala 2.11
@@ -14,7 +20,7 @@ matrix:
       scala: 2.10.4
       env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.0.0"
 script:
-  - sbt -Dhadoop.testVersion=$TEST_HADOOP_VERSION -Dspark.testVersion=$TEST_SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test
+  - sbt -Dhadoop.testVersion=$TEST_HADOOP_VERSION -Dspark.testVersion=$TEST_SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test coverageReport
   - sbt ++$TRAVIS_SCALA_VERSION scalastyle
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ libraryDependencies ++= Seq(
 // Display full-length stacktraces from ScalaTest:
 testOptions in Test += Tests.Argument("-oF")
 
-ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting := {
+coverageHighlighting := {
   if (scalaBinaryVersion.value == "2.10") false
   else true
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=0.13.11
+sbt.version=0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.3")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.1.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 


### PR DESCRIPTION
This patch updates the build to use SBT 0.13.13, Scoverage 1.5.0, and a newer set of Travis Ivy caching commands.