### PR TITLE
Cast to `Iterable` instead of `GenericData.Array` in SchemaConverters

### DIFF
--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -217,9 +217,7 @@ object SchemaConverters {
             if (item == null) {
               null
             } else {
-              val array = item.asInstanceOf[GenericData.Array[AnyRef]]
-
-              array.asScala.map { element =>
+              item.asInstanceOf[java.lang.Iterable[AnyRef]].asScala.map { element =>
                 if (element == null && !allowsNull) {
                   throw new RuntimeException(s"Array value at path ${path.mkString(".")} is not " +
                     "allowed to be null")


### PR DESCRIPTION
In the `ARRAY`-type handling code in `SchemaConverters` we always casted an array field's object to `GenericData.Array[AnyRef]`, which works fine as long as the Avro objects come from files but may break when they come in via other sources. To fix this, we can simply cast to `Iterable[AnyRef]` instead, since the code which uses the casted object is only calling methods from the `Iterable` interface.

This PR subsumes / closes #130 by @defg.