### PR TITLE
Add support for defaults defined in user-specified Avro schema

### DIFF
--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -415,6 +415,25 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
     assert(result.sameElements(expected))
   }
 
+  test("support user provided avro schema with defaults for missing fields") {
+    val avroSchema =
+      """
+        |{
+        |  "type" : "record",
+        |  "name" : "test_schema",
+        |  "fields" : [{
+        |    "name"    : "missingField",
+        |    "type"    : "string",
+        |    "default" : "foo"
+        |  }]
+        |}
+      """.stripMargin
+    val result = spark.read.option(DefaultSource.AvroSchema, avroSchema)
+      .avro(testFile).select("missingField").head(1)
+    val expected = Array(Row("foo"))
+    assert(result.sameElements(expected))
+  }
+
   test("reading from invalid path throws exception") {
 
     // Directory given has no avro files


### PR DESCRIPTION
This PR is based on @granturing's #173, with merge-conflicts fixed by @JoshRosen; the original description is as follows:

> The current Avro schema option does not seem to support defaults defined in the user-supplied schema. This is causing some confusion for users who are expecting default values but instead are getting `null`.
>
> This change forces the user-supplied Avro schema to be used for parsing and converting Avro records to Spark SQL Rows or it'll fall-back to the inferred schema if none is supplied.
>
> This is related to #176 
