### PR TITLE
Use user-provided avroSchema during writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ val df = spark.read
 df.filter("doctor > 5").write.format("com.databricks.spark.avro").save("/tmp/output")
 ```
 
-You can specify a custom Avro schema:
+You can specify a custom Avro schema for use during reads or writes:
 
 ```scala
 import org.apache.avro.Schema
@@ -172,6 +172,12 @@ spark
   .format("com.databricks.spark.avro")
   .option("avroSchema", schema.toString)
   .load("src/test/resources/episodes.avro").show()
+
+df
+  .write
+  .format("com.databricks.spark.avro")
+  .option("avroSchema", schema.toString)
+  .save("/tmp/output")
 ```
 
 You can also specify Avro compression options:

--- a/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
@@ -113,7 +113,9 @@ private[avro] class DefaultSource extends FileFormat with DataSourceRegister {
     val recordName = options.getOrElse("recordName", "topLevelRecord")
     val recordNamespace = options.getOrElse("recordNamespace", "")
     val build = SchemaBuilder.record(recordName).namespace(recordNamespace)
-    val outputAvroSchema = SchemaConverters.convertStructToAvro(dataSchema, build, recordNamespace)
+    val userProvidedSchema = options.get(AvroSchema).map(new Schema.Parser().parse)
+    val outputAvroSchema = userProvidedSchema.getOrElse(
+      SchemaConverters.convertStructToAvro(dataSchema, build, recordNamespace))
 
     AvroJob.setOutputKeySchema(job, outputAvroSchema)
     val AVRO_COMPRESSION_CODEC = "spark.sql.avro.compression.codec"

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -514,8 +514,9 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
     TestUtils.withTempDir { tempDir =>
       val savePath = s"$tempDir/save"
       strings.write.option(DefaultSource.AvroSchema, avroSchema).avro(savePath)
-      val readSchema = spark.read.avro(savePath).schema
-      assert(readSchema.fields === Seq(StructField("my_custom_field_name", StringType)))
+      val readDF = spark.read.avro(savePath)
+      assert(readDF.schema.fields === Seq(StructField("my_custom_field_name", StringType)))
+      assert(readDF.collect() === Seq(Row("Hello")))
     }
   }
 

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -509,7 +509,8 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
         |  }]
         |}
       """.stripMargin
-    val strings = spark.createDataFrame(Seq(Tuple1("Hello"), Tuple1("World")))
+    val strings = spark.createDataFrame(Seq(("Hello", "World")))
+    assert(strings.schema.fields.length == 2)
     TestUtils.withTempDir { tempDir =>
       val savePath = s"$tempDir/save"
       strings.write.option(DefaultSource.AvroSchema, avroSchema).avro(savePath)


### PR DESCRIPTION
This patch fixes #52 by honoring the `avroSchema` setting during writes.