### PR TITLE
Upgrade to spark 2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,18 +11,18 @@ before_cache:
   - find $HOME/.sbt -name "*.lock" -delete
 matrix:
   include:
-    # Spark 2.0.0, Scala 2.11, and Avro 1.7.x
+    # Spark 2.1.0, Scala 2.11, and Avro 1.7.x
     - jdk: openjdk7
-      scala: 2.11.7
-      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.0.0" TEST_AVRO_VERSION="1.7.6" TEST_AVRO_MAPRED_VERSION="1.7.7"
-    # Spark 2.0.0, Scala 2.10, and Avro 1.7.x
+      scala: 2.11.8
+      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.1.0" TEST_AVRO_VERSION="1.7.6" TEST_AVRO_MAPRED_VERSION="1.7.7"
+    # Spark 2.1.0, Scala 2.10, and Avro 1.7.x
     - jdk: openjdk7
-      scala: 2.10.4
-      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.0.0" TEST_AVRO_VERSION="1.7.6" TEST_AVRO_MAPRED_VERSION="1.7.7"
-    # Spark 2.0.0, Scala 2.10, and Avro 1.8.x
+      scala: 2.10.6
+      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.1.0" TEST_AVRO_VERSION="1.7.6" TEST_AVRO_MAPRED_VERSION="1.7.7"
+    # Spark 2.1.0, Scala 2.10, and Avro 1.8.x
     - jdk: openjdk7
-      scala: 2.10.4
-      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.0.0" TEST_AVRO_VERSION="1.8.0" TEST_AVRO_MAPRED_VERSION="1.8.0"
+      scala: 2.10.6
+      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.1.0" TEST_AVRO_VERSION="1.8.0" TEST_AVRO_MAPRED_VERSION="1.8.0"
 script:
   - ./dev/run-tests-travis.sh
 after_success:

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ crossScalaVersions := Seq("2.10.5", "2.11.7")
 
 spName := "databricks/spark-avro"
 
-sparkVersion := "2.0.0"
+sparkVersion := "2.1.0"
 
 val testSparkVersion = settingKey[String]("The version of Spark to test against.")
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ name := "spark-avro"
 
 organization := "com.databricks"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq("2.10.5", "2.11.7")
+crossScalaVersions := Seq("2.10.6", "2.11.8")
 
 spName := "databricks/spark-avro"
 

--- a/src/main/scala/com/databricks/spark/avro/AvroOutputWriter.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroOutputWriter.scala
@@ -54,10 +54,7 @@ private[avro] class AvroOutputWriter(
     new AvroKeyOutputFormat[GenericRecord]() {
 
       override def getDefaultWorkFile(context: TaskAttemptContext, extension: String): Path = {
-        val uniqueWriteJobId = context.getConfiguration.get("spark.sql.sources.writeJobUUID")
-        val taskAttemptId: TaskAttemptID = context.getTaskAttemptID
-        val split = taskAttemptId.getTaskID.getId
-        new Path(path, f"part-r-$split%05d-$uniqueWriteJobId$extension")
+        new Path(path) //, f"part-r-$split%05d-$uniqueWriteJobId$extension")
       }
 
       @throws(classOf[IOException])

--- a/src/main/scala/com/databricks/spark/avro/AvroOutputWriter.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroOutputWriter.scala
@@ -54,7 +54,7 @@ private[avro] class AvroOutputWriter(
     new AvroKeyOutputFormat[GenericRecord]() {
 
       override def getDefaultWorkFile(context: TaskAttemptContext, extension: String): Path = {
-        new Path(path) //, f"part-r-$split%05d-$uniqueWriteJobId$extension")
+        new Path(path)
       }
 
       @throws(classOf[IOException])

--- a/src/main/scala/com/databricks/spark/avro/AvroOutputWriterFactory.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroOutputWriterFactory.scala
@@ -26,9 +26,12 @@ private[avro] class AvroOutputWriterFactory(
     recordName: String,
     recordNamespace: String) extends OutputWriterFactory {
 
-  def newInstance(
+  override def getFileExtension(context: TaskAttemptContext): String = {
+    ".avro"
+  }
+
+  override def newInstance(
       path: String,
-      bucketId: Option[Int],
       dataSchema: StructType,
       context: TaskAttemptContext): OutputWriter = {
     new AvroOutputWriter(path, context, schema, recordName, recordNamespace)


### PR DESCRIPTION
Closes #205 

I am not entirely sure why i had to make changes in getDefaultWorkFile. Without these changes one extra (and unnecessary) layer of subdirectories was created upon writing, which meant no avro files were found upon reading.