### PR TITLE
Get ready for spark 2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,22 @@ before_cache:
   - find $HOME/.sbt -name "*.lock" -delete
 matrix:
   include:
-    # Spark 2.2.0-SNAPSHOT, Scala 2.11, and Avro 1.7.x
+    # Spark 2.2.0, Scala 2.11, and Avro 1.7.x
     - jdk: openjdk8
       scala: 2.11.8
-      env: TEST_HADOOP_VERSION="2.6.5" TEST_SPARK_VERSION="2.2.0-SNAPSHOT" TEST_AVRO_VERSION="1.7.6" TEST_AVRO_MAPRED_VERSION="1.7.7"
-    # Spark 2.2.0-SNAPSHOT, Scala 2.11, and Avro 1.8.x
+      env: TEST_HADOOP_VERSION="2.6.5" TEST_SPARK_VERSION="2.2.0" TEST_AVRO_VERSION="1.7.6" TEST_AVRO_MAPRED_VERSION="1.7.7"
+    # Spark 2.2.0, Scala 2.10, and Avro 1.7.x
+    - jdk: openjdk8
+      scala: 2.10.6
+      env: TEST_HADOOP_VERSION="2.6.5" TEST_SPARK_VERSION="2.2.0" TEST_AVRO_VERSION="1.7.6" TEST_AVRO_MAPRED_VERSION="1.7.7"
+    # Spark 2.2.0, Scala 2.11, and Avro 1.8.x
     - jdk: openjdk8
       scala: 2.11.8
-      env: TEST_HADOOP_VERSION="2.6.5" TEST_SPARK_VERSION="2.2.0-SNAPSHOT" TEST_AVRO_VERSION="1.8.0" TEST_AVRO_MAPRED_VERSION="1.8.0"
+      env: TEST_HADOOP_VERSION="2.6.5" TEST_SPARK_VERSION="2.2.0" TEST_AVRO_VERSION="1.8.0" TEST_AVRO_MAPRED_VERSION="1.8.0"
+    # Spark 2.2.0, Scala 2.10, and Avro 1.8.x
+    - jdk: openjdk8
+      scala: 2.10.6
+      env: TEST_HADOOP_VERSION="2.6.5" TEST_SPARK_VERSION="2.2.0" TEST_AVRO_VERSION="1.8.0" TEST_AVRO_MAPRED_VERSION="1.8.0"
 script:
   - ./dev/run-tests-travis.sh
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: scala
 sudo: false
 # Cache settings here are based on latest SBT documentation.

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,18 +11,14 @@ before_cache:
   - find $HOME/.sbt -name "*.lock" -delete
 matrix:
   include:
-    # Spark 2.1.0, Scala 2.11, and Avro 1.7.x
-    - jdk: openjdk7
+    # Spark 2.2.0-SNAPSHOT, Scala 2.11, and Avro 1.7.x
+    - jdk: openjdk8
       scala: 2.11.8
-      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.1.0" TEST_AVRO_VERSION="1.7.6" TEST_AVRO_MAPRED_VERSION="1.7.7"
-    # Spark 2.1.0, Scala 2.10, and Avro 1.7.x
-    - jdk: openjdk7
-      scala: 2.10.6
-      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.1.0" TEST_AVRO_VERSION="1.7.6" TEST_AVRO_MAPRED_VERSION="1.7.7"
-    # Spark 2.1.0, Scala 2.10, and Avro 1.8.x
-    - jdk: openjdk7
-      scala: 2.10.6
-      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.1.0" TEST_AVRO_VERSION="1.8.0" TEST_AVRO_MAPRED_VERSION="1.8.0"
+      env: TEST_HADOOP_VERSION="2.6.5" TEST_SPARK_VERSION="2.2.0-SNAPSHOT" TEST_AVRO_VERSION="1.7.6" TEST_AVRO_MAPRED_VERSION="1.7.7"
+    # Spark 2.2.0-SNAPSHOT, Scala 2.11, and Avro 1.8.x
+    - jdk: openjdk8
+      scala: 2.11.8
+      env: TEST_HADOOP_VERSION="2.6.5" TEST_SPARK_VERSION="2.2.0-SNAPSHOT" TEST_AVRO_VERSION="1.8.0" TEST_AVRO_MAPRED_VERSION="1.8.0"
 script:
   - ./dev/run-tests-travis.sh
 after_success:

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ crossScalaVersions := Seq("2.10.6", "2.11.8")
 
 spName := "databricks/spark-avro"
 
-sparkVersion := "2.1.0"
+sparkVersion := "2.2.0-SNAPSHOT"
 
 val testSparkVersion = settingKey[String]("The version of Spark to test against.")
 
@@ -16,7 +16,7 @@ testSparkVersion := sys.props.getOrElse("spark.testVersion", sparkVersion.value)
 
 val testHadoopVersion = settingKey[String]("The version of Hadoop to test against.")
 
-testHadoopVersion := sys.props.getOrElse("hadoop.testVersion", "2.2.0")
+testHadoopVersion := sys.props.getOrElse("hadoop.testVersion", "2.6.5")
 
 val testAvroVersion = settingKey[String]("The version of Avro to test against.")
 
@@ -34,6 +34,8 @@ spIgnoreProvided := true
 
 sparkComponents := Seq("sql")
 
+resolvers += "asf snapshots" at "http://repository.apache.org/snapshots/"
+
 libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-api" % "1.7.5",
   "org.apache.avro" % "avro" % "1.7.6" exclude("org.mortbay.jetty", "servlet-api"),
@@ -49,7 +51,8 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % testSparkVersion.value % "test" exclude("org.apache.hadoop", "hadoop-client"),
   "org.apache.spark" %% "spark-sql" % testSparkVersion.value % "test" exclude("org.apache.hadoop", "hadoop-client"),
   "org.apache.avro" % "avro" % testAvroVersion.value % "test" exclude("org.mortbay.jetty", "servlet-api"),
-  "org.apache.avro" % "avro-mapred" % testAvroMapredVersion.value  % "test" classifier("hadoop2") exclude("org.mortbay.jetty", "servlet-api")
+  "org.apache.avro" % "avro-mapred" % testAvroMapredVersion.value  % "test" classifier("hadoop2") exclude("org.mortbay.jetty", "servlet-api"),
+  "com.google.guava" % "guava" % "14.0.1" % "test" force()
 )
 
 // Display full-length stacktraces from ScalaTest:

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ crossScalaVersions := Seq("2.10.6", "2.11.8")
 
 spName := "databricks/spark-avro"
 
-sparkVersion := "2.2.0-SNAPSHOT"
+sparkVersion := "2.2.0"
 
 val testSparkVersion = settingKey[String]("The version of Spark to test against.")
 
@@ -33,8 +33,6 @@ spIncludeMaven := true
 spIgnoreProvided := true
 
 sparkComponents := Seq("sql")
-
-resolvers += "asf snapshots" at "http://repository.apache.org/snapshots/"
 
 libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-api" % "1.7.5",


### PR DESCRIPTION
DO NOT MERGE (yet)

Note that if i do not pin guava i get:
```
[info] Exception encountered when attempting to run a suite with class name: com.databricks.spark.avro.AvroSuite *** ABORTED ***
[info]   java.lang.NoSuchMethodError: com.google.common.base.Stopwatch.elapsedMillis()J
[info]   at org.apache.hadoop.mapred.FileInputFormat.listStatus(FileInputFormat.java:245)
[info]   at org.apache.hadoop.mapred.FileInputFormat.getSplits(FileInputFormat.java:313)
[info]   at org.apache.spark.rdd.HadoopRDD.getPartitions(HadoopRDD.scala:194)
[info]   at org.apache.spark.rdd.RDD$$anonfun$partitions$2.apply(RDD.scala:252)
[info]   at org.apache.spark.rdd.RDD$$anonfun$partitions$2.apply(RDD.scala:250)
[info]   at scala.Option.getOrElse(Option.scala:121)
[info]   at org.apache.spark.rdd.RDD.partitions(RDD.scala:250)
[info]   at org.apache.spark.rdd.MapPartitionsRDD.getPartitions(MapPartitionsRDD.scala:35)
[info]   at org.apache.spark.rdd.RDD$$anonfun$partitions$2.apply(RDD.scala:252)
[info]   at org.apache.spark.rdd.RDD$$anonfun$partitions$2.apply(RDD.scala:250)
[info]   at scala.Option.getOrElse(Option.scala:121)
[info]   at org.apache.spark.rdd.RDD.partitions(RDD.scala:250)
[info]   at org.apache.spark.SparkContext.runJob(SparkContext.scala:2084)
[info]   at org.apache.spark.rdd.RDD$$anonfun$collect$1.apply(RDD.scala:936)
[info]   at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:151)
[info]   at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:112)
[info]   at org.apache.spark.rdd.RDD.withScope(RDD.scala:362)
[info]   at org.apache.spark.rdd.RDD.collect(RDD.scala:935)
[info]   at com.databricks.spark.avro.AvroSuite$$anonfun$20$$anonfun$apply$mcV$sp$18.apply(AvroSuite.scala:462)
[info]   at com.databricks.spark.avro.AvroSuite$$anonfun$20$$anonfun$apply$mcV$sp$18.apply(AvroSuite.scala:451)
[info]   at com.databricks.spark.avro.TestUtils$.withTempDir(TestUtils.scala:75)
[info]   at com.databricks.spark.avro.AvroSuite$$anonfun$20.apply$mcV$sp(AvroSuite.scala:451)
[info]   at com.databricks.spark.avro.AvroSuite$$anonfun$20.apply(AvroSuite.scala:451)
[info]   at com.databricks.spark.avro.AvroSuite$$anonfun$20.apply(AvroSuite.scala:451)
[info]   at org.scalatest.Transformer$$anonfun$apply$1.apply$mcV$sp(Transformer.scala:22)
[info]   at org.scalatest.OutcomeOf$class.outcomeOf(OutcomeOf.scala:85)
[info]   at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:22)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:20)
[info]   at org.scalatest.FunSuiteLike$$anon$1.apply(FunSuiteLike.scala:166)
[info]   at org.scalatest.Suite$class.withFixture(Suite.scala:1122)
[info]   at org.scalatest.FunSuite.withFixture(FunSuite.scala:1555)
[info]   at org.scalatest.FunSuiteLike$class.invokeWithFixture$1(FunSuiteLike.scala:163)
[info]   at org.scalatest.FunSuiteLike$$anonfun$runTest$1.apply(FunSuiteLike.scala:175)
[info]   at org.scalatest.FunSuiteLike$$anonfun$runTest$1.apply(FunSuiteLike.scala:175)
[info]   at org.scalatest.SuperEngine.runTestImpl(Engine.scala:306)
[info]   at org.scalatest.FunSuiteLike$class.runTest(FunSuiteLike.scala:175)
[info]   at org.scalatest.FunSuite.runTest(FunSuite.scala:1555)
[info]   at org.scalatest.FunSuiteLike$$anonfun$runTests$1.apply(FunSuiteLike.scala:208)
[info]   at org.scalatest.FunSuiteLike$$anonfun$runTests$1.apply(FunSuiteLike.scala:208)
[info]   at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:413)
[info]   at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:401)
[info]   at scala.collection.immutable.List.foreach(List.scala:381)
[info]   at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
[info]   at org.scalatest.SuperEngine.org$scalatest$SuperEngine$$runTestsInBranch(Engine.scala:396)
[info]   at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:483)
[info]   at org.scalatest.FunSuiteLike$class.runTests(FunSuiteLike.scala:208)
[info]   at org.scalatest.FunSuite.runTests(FunSuite.scala:1555)
[info]   at org.scalatest.Suite$class.run(Suite.scala:1424)
[info]   at org.scalatest.FunSuite.org$scalatest$FunSuiteLike$$super$run(FunSuite.scala:1555)
[info]   at org.scalatest.FunSuiteLike$$anonfun$run$1.apply(FunSuiteLike.scala:212)
[info]   at org.scalatest.FunSuiteLike$$anonfun$run$1.apply(FunSuiteLike.scala:212)
[info]   at org.scalatest.SuperEngine.runImpl(Engine.scala:545)
[info]   at org.scalatest.FunSuiteLike$class.run(FunSuiteLike.scala:212)
[info]   at com.databricks.spark.avro.AvroSuite.org$scalatest$BeforeAndAfterAll$$super$run(AvroSuite.scala:38)
[info]   at org.scalatest.BeforeAndAfterAll$class.liftedTree1$1(BeforeAndAfterAll.scala:257)
[info]   at org.scalatest.BeforeAndAfterAll$class.run(BeforeAndAfterAll.scala:256)
[info]   at com.databricks.spark.avro.AvroSuite.run(AvroSuite.scala:38)
[info]   at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:462)
[info]   at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:671)
[info]   at sbt.TestRunner.runTest$1(TestFramework.scala:76)
[info]   at sbt.TestRunner.run(TestFramework.scala:85)
[info]   at sbt.TestFramework$$anon$2$$anonfun$$init$$1$$anonfun$apply$8.apply(TestFramework.scala:202)
[info]   at sbt.TestFramework$$anon$2$$anonfun$$init$$1$$anonfun$apply$8.apply(TestFramework.scala:202)
[info]   at sbt.TestFramework$.sbt$TestFramework$$withContextLoader(TestFramework.scala:185)
[info]   at sbt.TestFramework$$anon$2$$anonfun$$init$$1.apply(TestFramework.scala:202)
[info]   at sbt.TestFramework$$anon$2$$anonfun$$init$$1.apply(TestFramework.scala:202)
[info]   at sbt.TestFunction.apply(TestFramework.scala:207)
[info]   at sbt.Tests$$anonfun$9.apply(Tests.scala:216)
[info]   at sbt.Tests$$anonfun$9.apply(Tests.scala:216)
[info]   at sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:44)
[info]   at sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:44)
[info]   at sbt.std.Transform$$anon$4.work(System.scala:63)
[info]   at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
[info]   at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
[info]   at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
[info]   at sbt.Execute.work(Execute.scala:237)
[info]   at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
[info]   at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
[info]   at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
[info]   at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
[info]   at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[info]   at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[info]   at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[info]   at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
[info]   at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
[info]   at java.lang.Thread.run(Thread.java:745)
```

