### PR TITLE
Spark 2.2.0 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,14 @@ matrix:
     - jdk: openjdk7
       scala: 2.10.6
       env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.1.0" TEST_AVRO_VERSION="1.8.0" TEST_AVRO_MAPRED_VERSION="1.8.0"
+    # Spark 2.2.0, Scala 2.11, and Avro 1.7.x
+    - jdk: openjdk8
+      scala: 2.11.8
+      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.2.0" TEST_AVRO_VERSION="1.7.6" TEST_AVRO_MAPRED_VERSION="1.7.7"
+    # Spark 2.2.0, Scala 2.10, and Avro 1.8.x
+    - jdk: openjdk8
+      scala: 2.10.6
+      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.2.0" TEST_AVRO_VERSION="1.8.0" TEST_AVRO_MAPRED_VERSION="1.8.0"
 script:
   - ./dev/run-tests-travis.sh
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,11 @@ matrix:
     # Spark 2.2.0, Scala 2.11, and Avro 1.7.x
     - jdk: openjdk8
       scala: 2.11.8
-      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.2.0" TEST_AVRO_VERSION="1.7.6" TEST_AVRO_MAPRED_VERSION="1.7.7"
+      env: TEST_HADOOP_VERSION="2.6.5" TEST_SPARK_VERSION="2.2.0" TEST_AVRO_VERSION="1.7.6" TEST_AVRO_MAPRED_VERSION="1.7.7"
     # Spark 2.2.0, Scala 2.10, and Avro 1.8.x
     - jdk: openjdk8
       scala: 2.10.6
-      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.2.0" TEST_AVRO_VERSION="1.8.0" TEST_AVRO_MAPRED_VERSION="1.8.0"
+      env: TEST_HADOOP_VERSION="2.6.5" TEST_SPARK_VERSION="2.2.0" TEST_AVRO_VERSION="1.8.0" TEST_AVRO_MAPRED_VERSION="1.8.0"
 script:
   - ./dev/run-tests-travis.sh
 after_success:

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ This library has different versions for Spark 1.2, 1.3, 1.4+, 2.0 - 2.1, and 2.2
 | `2.0 - 2.1`         | `3.2.0` (latest released version)                           |
 | `2.2`         | `3.3.0` (unreleased)                           |
 
-Version 3.3.0 can be used with spark 2.0 & 2.1, but *only if* you are using JDK 8.  (Spark 2.2 requires JDK 8 in any case.)
-
 ## Linking
 
 This library is cross-published for Scala 2.11, so 2.11 users should replace 2.10 with 2.11 in the commands listed below.

--- a/README.md
+++ b/README.md
@@ -10,14 +10,17 @@ A library for reading and writing Avro data from [Spark SQL](http://spark.apache
 This documentation is for version 3.1.0 of this library, which supports Spark 2.0+. For
 documentation on earlier versions of this library, see the links below.
 
-This library has different versions for Spark 1.2, 1.3, 1.4+, and 2.0:
+This library has different versions for Spark 1.2, 1.3, 1.4+, 2.0 - 2.1, and 2.2:
 
 | Spark Version | Compatible version of Avro Data Source for Spark |
 | ------------- | ------------------------------------------------ |
 | `1.2`         | `0.2.0`                                          |
 | `1.3`         | [`1.0.0`](https://github.com/databricks/spark-avro/tree/v1.0.0) |
 | `1.4+`        | [`2.0.1`](https://github.com/databricks/spark-avro/tree/v2.0.1) |
-| `2.0`         | `3.1.0` (this version)                           |
+| `2.0 - 2.1`         | `3.2.0` (latest released version)                           |
+| `2.2`         | `3.3.0` (unreleased)                           |
+
+Version 3.3.0 can be used with spark 2.0 & 2.1, but *only if* you are using JDK 8.  (Spark 2.2 requires JDK 8 in any case.)
 
 ## Linking
 

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ testSparkVersion := sys.props.getOrElse("spark.testVersion", sparkVersion.value)
 
 val testHadoopVersion = settingKey[String]("The version of Hadoop to test against.")
 
-testHadoopVersion := sys.props.getOrElse("hadoop.testVersion", "2.6.5")
+testHadoopVersion := sys.props.getOrElse("hadoop.testVersion", "2.2.0")
 
 val testAvroVersion = settingKey[String]("The version of Avro to test against.")
 

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ testSparkVersion := sys.props.getOrElse("spark.testVersion", sparkVersion.value)
 
 val testHadoopVersion = settingKey[String]("The version of Hadoop to test against.")
 
-testHadoopVersion := sys.props.getOrElse("hadoop.testVersion", "2.2.0")
+testHadoopVersion := sys.props.getOrElse("hadoop.testVersion", "2.6.5")
 
 val testAvroVersion = settingKey[String]("The version of Avro to test against.")
 
@@ -44,10 +44,13 @@ libraryDependencies ++= Seq(
   "commons-io" % "commons-io" % "2.4" % "test"
 )
 
+// curator leads to conflicting guava dependencies
+val curatorExclusion = ExclusionRule(organization = "org.apache.curator")
+
 libraryDependencies ++= Seq(
-  "org.apache.hadoop" % "hadoop-client" % testHadoopVersion.value % "test",
-  "org.apache.spark" %% "spark-core" % testSparkVersion.value % "test" exclude("org.apache.hadoop", "hadoop-client"),
-  "org.apache.spark" %% "spark-sql" % testSparkVersion.value % "test" exclude("org.apache.hadoop", "hadoop-client"),
+  "org.apache.hadoop" % "hadoop-client" % testHadoopVersion.value % "test" excludeAll(curatorExclusion),
+  "org.apache.spark" %% "spark-core" % testSparkVersion.value % "test" exclude("org.apache.hadoop", "hadoop-client") excludeAll(curatorExclusion),
+  "org.apache.spark" %% "spark-sql" % testSparkVersion.value % "test" exclude("org.apache.hadoop", "hadoop-client") excludeAll(curatorExclusion),
   "org.apache.avro" % "avro" % testAvroVersion.value % "test" exclude("org.mortbay.jetty", "servlet-api"),
   "org.apache.avro" % "avro-mapred" % testAvroMapredVersion.value  % "test" classifier("hadoop2") exclude("org.mortbay.jetty", "servlet-api")
 )

--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ testOptions in Test += Tests.Argument("-oF")
 
 scalacOptions ++= Seq("-target:jvm-1.7")
 
-javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
+javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 
 coverageHighlighting := {
   if (scalaBinaryVersion.value == "2.10") false

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ crossScalaVersions := Seq("2.10.6", "2.11.8")
 
 spName := "databricks/spark-avro"
 
-sparkVersion := "2.2.0"
+sparkVersion := "2.1.0"
 
 val testSparkVersion = settingKey[String]("The version of Spark to test against.")
 
@@ -60,7 +60,7 @@ testOptions in Test += Tests.Argument("-oF")
 
 scalacOptions ++= Seq("-target:jvm-1.7")
 
-javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
+javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
 
 coverageHighlighting := {
   if (scalaBinaryVersion.value == "2.10") false

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ crossScalaVersions := Seq("2.10.6", "2.11.8")
 
 spName := "databricks/spark-avro"
 
-sparkVersion := "2.1.0"
+sparkVersion := "2.2.0"
 
 val testSparkVersion = settingKey[String]("The version of Spark to test against.")
 


### PR DESCRIPTION
This adds support for spark 2.2.0.  Primarily this is addressing the api change introduced by [SPARK-19085](https://issues.apache.org/jira/browse/SPARK-19085) https://github.com/apache/spark/commit/b3d39620c563e5f6a32a4082aa3908e1009c17d2.  This fixes the issue in the most simplistic way: it copies the old conversion from `InternalRow` to `Row`.  A better implementation would do something more efficient with `InternalRow`.

This keeps both `write()` methods, so it should be compatible with all spark 2+ versions.

It also fixes some dependency conflicts when running tests -- it seems curator has a conflicting version of guava with hadoop, but we don't actually need curator for tests.

Tested by running unit tests locally.

Fixes https://github.com/databricks/spark-avro/issues/240