### PR TITLE
Fix bug on generation of avro files with nested records with the same name

### DIFF
--- a/src/main/scala/com/databricks/spark/avro/AvroOutputWriter.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroOutputWriter.scala
@@ -107,8 +107,7 @@ private[avro] class AvroOutputWriter(
         val elementConverter = createConverterToAvro(
           elementType,
           structName,
-          SchemaConverters.getNewRecordNamespace(elementType, recordNamespace, structName)
-          )
+          SchemaConverters.getNewRecordNamespace(elementType, recordNamespace, structName))
         (item: Any) => {
           if (item == null) {
             null
@@ -128,8 +127,7 @@ private[avro] class AvroOutputWriter(
         val valueConverter = createConverterToAvro(
           valueType,
           structName,
-          SchemaConverters.getNewRecordNamespace(valueType, recordNamespace, structName)
-          )
+          SchemaConverters.getNewRecordNamespace(valueType, recordNamespace, structName))
         (item: Any) => {
           if (item == null) {
             null
@@ -149,9 +147,7 @@ private[avro] class AvroOutputWriter(
           createConverterToAvro(
             field.dataType,
             field.name,
-            SchemaConverters.getNewRecordNamespace(field.dataType, recordNamespace, field.name)
-            )
-        )
+            SchemaConverters.getNewRecordNamespace(field.dataType, recordNamespace, field.name)))
         (item: Any) => {
           if (item == null) {
             null

--- a/src/main/scala/com/databricks/spark/avro/AvroOutputWriter.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroOutputWriter.scala
@@ -104,7 +104,13 @@ private[avro] class AvroOutputWriter(
       case DateType => (item: Any) =>
         if (item == null) null else item.asInstanceOf[Date].getTime
       case ArrayType(elementType, _) =>
-        val elementConverter = createConverterToAvro(elementType, structName, recordNamespace)
+        val elementConverter = createConverterToAvro(
+          elementType,
+          structName,
+          elementType match {
+            case StructType(_) => s"$recordNamespace.$structName"
+            case _ => recordNamespace
+          })
         (item: Any) => {
           if (item == null) {
             null
@@ -121,7 +127,13 @@ private[avro] class AvroOutputWriter(
           }
         }
       case MapType(StringType, valueType, _) =>
-        val valueConverter = createConverterToAvro(valueType, structName, recordNamespace)
+        val valueConverter = createConverterToAvro(
+          valueType,
+          structName,
+          valueType match {
+            case StructType(_) => s"$recordNamespace.$structName"
+            case _ => recordNamespace
+          })
         (item: Any) => {
           if (item == null) {
             null
@@ -138,7 +150,13 @@ private[avro] class AvroOutputWriter(
         val schema: Schema = SchemaConverters.convertStructToAvro(
           structType, builder, recordNamespace)
         val fieldConverters = structType.fields.map(field =>
-          createConverterToAvro(field.dataType, field.name, recordNamespace))
+          createConverterToAvro(field.dataType,
+            field.name,
+            field.dataType match{
+              case StructType(_) => s"$recordNamespace.${field.name}"
+              case _ => recordNamespace
+            }
+          ))
         (item: Any) => {
           if (item == null) {
             null

--- a/src/main/scala/com/databricks/spark/avro/AvroOutputWriter.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroOutputWriter.scala
@@ -107,10 +107,8 @@ private[avro] class AvroOutputWriter(
         val elementConverter = createConverterToAvro(
           elementType,
           structName,
-          elementType match {
-            case StructType(_) => s"$recordNamespace.$structName"
-            case _ => recordNamespace
-          })
+          SchemaConverters.getNewRecordNameSpace(elementType, recordNamespace, structName)
+          )
         (item: Any) => {
           if (item == null) {
             null
@@ -130,10 +128,8 @@ private[avro] class AvroOutputWriter(
         val valueConverter = createConverterToAvro(
           valueType,
           structName,
-          valueType match {
-            case StructType(_) => s"$recordNamespace.$structName"
-            case _ => recordNamespace
-          })
+          SchemaConverters.getNewRecordNameSpace(valueType, recordNamespace, structName)
+          )
         (item: Any) => {
           if (item == null) {
             null
@@ -150,13 +146,12 @@ private[avro] class AvroOutputWriter(
         val schema: Schema = SchemaConverters.convertStructToAvro(
           structType, builder, recordNamespace)
         val fieldConverters = structType.fields.map(field =>
-          createConverterToAvro(field.dataType,
+          createConverterToAvro(
+            field.dataType,
             field.name,
-            field.dataType match{
-              case StructType(_) => s"$recordNamespace.${field.name}"
-              case _ => recordNamespace
-            }
-          ))
+            SchemaConverters.getNewRecordNameSpace(field.dataType, recordNamespace, field.name)
+            )
+        )
         (item: Any) => {
           if (item == null) {
             null

--- a/src/main/scala/com/databricks/spark/avro/AvroOutputWriter.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroOutputWriter.scala
@@ -107,7 +107,7 @@ private[avro] class AvroOutputWriter(
         val elementConverter = createConverterToAvro(
           elementType,
           structName,
-          SchemaConverters.getNewRecordNameSpace(elementType, recordNamespace, structName)
+          SchemaConverters.getNewRecordNamespace(elementType, recordNamespace, structName)
           )
         (item: Any) => {
           if (item == null) {
@@ -128,7 +128,7 @@ private[avro] class AvroOutputWriter(
         val valueConverter = createConverterToAvro(
           valueType,
           structName,
-          SchemaConverters.getNewRecordNameSpace(valueType, recordNamespace, structName)
+          SchemaConverters.getNewRecordNamespace(valueType, recordNamespace, structName)
           )
         (item: Any) => {
           if (item == null) {
@@ -149,7 +149,7 @@ private[avro] class AvroOutputWriter(
           createConverterToAvro(
             field.dataType,
             field.name,
-            SchemaConverters.getNewRecordNameSpace(field.dataType, recordNamespace, field.name)
+            SchemaConverters.getNewRecordNamespace(field.dataType, recordNamespace, field.name)
             )
         )
         (item: Any) => {

--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -376,19 +376,33 @@ object SchemaConverters {
 
       case ArrayType(elementType, _) =>
         val builder = getSchemaBuilder(dataType.asInstanceOf[ArrayType].containsNull)
-        val elementSchema = convertTypeToAvro(elementType, builder, structName, recordNamespace)
+        val elementSchema = convertTypeToAvro(
+          elementType,
+          builder,
+          structName,
+          elementType match {
+            case StructType(_) => s"$recordNamespace.$structName"
+            case _ => recordNamespace
+          })
         newFieldBuilder.array().items(elementSchema)
 
       case MapType(StringType, valueType, _) =>
         val builder = getSchemaBuilder(dataType.asInstanceOf[MapType].valueContainsNull)
-        val valueSchema = convertTypeToAvro(valueType, builder, structName, recordNamespace)
+        val valueSchema = convertTypeToAvro(
+          valueType,
+          builder,
+          structName,
+          valueType match {
+            case StructType(_) => s"$recordNamespace.$structName"
+            case _ => recordNamespace
+          })
         newFieldBuilder.map().values(valueSchema)
 
       case structType: StructType =>
         convertStructToAvro(
           structType,
-          newFieldBuilder.record(structName).namespace(recordNamespace),
-          recordNamespace)
+          newFieldBuilder.record(structName).namespace(s"$recordNamespace.$structName"),
+          s"$recordNamespace.$structName")
 
       case other => throw new IncompatibleSchemaException(s"Unexpected type $dataType.")
     }

--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -380,7 +380,7 @@ object SchemaConverters {
           elementType,
           builder,
           structName,
-          getNewRecordNameSpace(elementType, recordNamespace, structName)
+          getNewRecordNamespace(elementType, recordNamespace, structName)
           )
         newFieldBuilder.array().items(elementSchema)
 
@@ -390,7 +390,7 @@ object SchemaConverters {
           valueType,
           builder,
           structName,
-          getNewRecordNameSpace(valueType, recordNamespace, structName)
+          getNewRecordNamespace(valueType, recordNamespace, structName)
           )
         newFieldBuilder.map().values(valueSchema)
 
@@ -409,7 +409,7 @@ object SchemaConverters {
     * If the data type is a StructType it returns the current namespace concatenated
     * with the element name, otherwise it returns the current namespace as it is.
     */
-  private[avro] def getNewRecordNameSpace(
+  private[avro] def getNewRecordNamespace(
       elementDataType: DataType,
       currentRecordNamespace: String,
       elementName: String): String = {

--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -380,10 +380,8 @@ object SchemaConverters {
           elementType,
           builder,
           structName,
-          elementType match {
-            case StructType(_) => s"$recordNamespace.$structName"
-            case _ => recordNamespace
-          })
+          getNewRecordNameSpace(elementType, recordNamespace, structName)
+          )
         newFieldBuilder.array().items(elementSchema)
 
       case MapType(StringType, valueType, _) =>
@@ -392,10 +390,8 @@ object SchemaConverters {
           valueType,
           builder,
           structName,
-          valueType match {
-            case StructType(_) => s"$recordNamespace.$structName"
-            case _ => recordNamespace
-          })
+          getNewRecordNameSpace(valueType, recordNamespace, structName)
+          )
         newFieldBuilder.map().values(valueSchema)
 
       case structType: StructType =>
@@ -405,6 +401,22 @@ object SchemaConverters {
           s"$recordNamespace.$structName")
 
       case other => throw new IncompatibleSchemaException(s"Unexpected type $dataType.")
+    }
+  }
+
+  /**
+    * Returns a new namespace depending on the data type of the element.
+    * If the data type is a StructType it returns the current namespace concatenated
+    * with the element name, otherwise it returns the current namespace as it is.
+    */
+  private[avro] def getNewRecordNameSpace(
+      elementDataType: DataType,
+      currentRecordNamespace: String,
+      elementName: String): String = {
+
+    elementDataType match {
+      case StructType(_) => s"$currentRecordNamespace.$elementName"
+      case _ => currentRecordNamespace
     }
   }
 

--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -380,8 +380,7 @@ object SchemaConverters {
           elementType,
           builder,
           structName,
-          getNewRecordNamespace(elementType, recordNamespace, structName)
-          )
+          getNewRecordNamespace(elementType, recordNamespace, structName))
         newFieldBuilder.array().items(elementSchema)
 
       case MapType(StringType, valueType, _) =>
@@ -390,8 +389,7 @@ object SchemaConverters {
           valueType,
           builder,
           structName,
-          getNewRecordNamespace(valueType, recordNamespace, structName)
-          )
+          getNewRecordNamespace(valueType, recordNamespace, structName))
         newFieldBuilder.map().values(valueSchema)
 
       case structType: StructType =>

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -693,4 +693,15 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
       assert(input.rdd.partitions.size > 2)
     }
   }
+
+  case class NestedBottom(id: Int, data: String)
+  case class NestedMiddle(id: Int, data: NestedBottom)
+  case class NestedTop(id: Int, data: NestedMiddle)
+
+  test("saving avro that has nested records with the same name") {
+    TestUtils.withTempDir { tempDir =>
+      val df = spark.createDataFrame(List(NestedTop(1, NestedMiddle(2, NestedBottom(3, "1")))))
+      df.write.avro(s"$tempDir/duplicate_names/")
+    }
+  }
 }

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -707,7 +707,7 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
       // Read avro file saved on the last step
       val readDf = spark.read.avro(outputFolder)
       // Check if the written DataFrame is equals than read DataFrame
-      assert(readDf.collect() sameElements writeDf.collect())
+      assert(readDf.collect().sameElements(writeDf.collect()))
     }
   }
 
@@ -728,7 +728,7 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
       // Read avro file saved on the last step
       val readDf = spark.read.avro(outputFolder)
       // Check if the written DataFrame is equals than read DataFrame
-      assert(readDf.collect() sameElements writeDf.collect())
+      assert(readDf.collect().sameElements(writeDf.collect()))
     }
   }
 
@@ -749,7 +749,7 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
       // Read avro file saved on the last step
       val readDf = spark.read.avro(outputFolder)
       // Check if the written DataFrame is equals than read DataFrame
-      assert(readDf.collect() sameElements writeDf.collect())
+      assert(readDf.collect().sameElements(writeDf.collect()))
     }
   }
 }

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -17,7 +17,6 @@
 package com.databricks.spark.avro
 
 import java.io._
-import java.nio.ByteBuffer
 import java.nio.file.Files
 import java.sql.{Date, Timestamp}
 import java.util.{TimeZone, UUID}
@@ -29,7 +28,6 @@ import org.apache.avro.file.DataFileWriter
 import org.apache.avro.generic.{GenericData, GenericDatumWriter, GenericRecord}
 import org.apache.avro.generic.GenericData.{EnumSymbol, Fixed}
 import org.apache.commons.io.FileUtils
-import org.apache.spark.SparkContext
 import org.apache.spark.sql._
 import org.apache.spark.sql.types._
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
@@ -695,13 +693,63 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   case class NestedBottom(id: Int, data: String)
+
   case class NestedMiddle(id: Int, data: NestedBottom)
+
   case class NestedTop(id: Int, data: NestedMiddle)
 
   test("saving avro that has nested records with the same name") {
     TestUtils.withTempDir { tempDir =>
-      val df = spark.createDataFrame(List(NestedTop(1, NestedMiddle(2, NestedBottom(3, "1")))))
-      df.write.avro(s"$tempDir/duplicate_names/")
+      // Save avro file on output folder path
+      val writeDf = spark.createDataFrame(List(NestedTop(1, NestedMiddle(2, NestedBottom(3, "1")))))
+      val outputFolder = s"$tempDir/duplicate_names/"
+      writeDf.write.avro(outputFolder)
+      // Read avro file saved on the last step
+      val readDf = spark.read.avro(outputFolder)
+      // Check if the written DataFrame is equals than read DataFrame
+      assert(readDf.collect() sameElements writeDf.collect())
+    }
+  }
+
+  case class NestedMiddleArray(id: Int, data: Array[NestedBottom])
+
+  case class NestedTopArray(id: Int, data: NestedMiddleArray)
+
+  test("saving avro that has nested records with the same name inside an array") {
+    TestUtils.withTempDir { tempDir =>
+      // Save avro file on output folder path
+      val writeDf = spark.createDataFrame(
+        List(NestedTopArray(1, NestedMiddleArray(2, Array(
+          NestedBottom(3, "1"), NestedBottom(4, "2")
+        ))))
+      )
+      val outputFolder = s"$tempDir/duplicate_names_array/"
+      writeDf.write.avro(outputFolder)
+      // Read avro file saved on the last step
+      val readDf = spark.read.avro(outputFolder)
+      // Check if the written DataFrame is equals than read DataFrame
+      assert(readDf.collect() sameElements writeDf.collect())
+    }
+  }
+
+  case class NestedMiddleMap(id: Int, data: Map[String, NestedBottom])
+
+  case class NestedTopMap(id: Int, data: NestedMiddleMap)
+
+  test("saving avro that has nested records with the same name inside a map") {
+    TestUtils.withTempDir { tempDir =>
+      // Save avro file on output folder path
+      val writeDf = spark.createDataFrame(
+        List(NestedTopMap(1, NestedMiddleMap(2, Map(
+          "1" -> NestedBottom(3, "1"), "2" -> NestedBottom(4, "2")
+        ))))
+      )
+      val outputFolder = s"$tempDir/duplicate_names_map/"
+      writeDf.write.avro(outputFolder)
+      // Read avro file saved on the last step
+      val readDf = spark.read.avro(outputFolder)
+      // Check if the written DataFrame is equals than read DataFrame
+      assert(readDf.collect() sameElements writeDf.collect())
     }
   }
 }


### PR DESCRIPTION
spark-avro was failing on the generation of avro files when nested records had the same name, as can be seen on the following issue [#54](https://github.com/databricks/spark-avro/issues/54). 
For solving that problem has been added a different namespace on each record. This namespace is created with the concatenation of all the parents of each record separated by dot.
Added also a new test in AvroSuite for checking the new code.
This is related with pull request [#73](https://github.com/databricks/spark-avro/pull/73) but have been added a modification on AvroOutputWriter to solve correctly the issue.