### PR TITLE
Fix java.lang.Double is not valid external type for Decimal(10,10) issue in test AvroWriteBenchmark

### DIFF
--- a/src/test/scala/com/databricks/spark/avro/AvroWriteBenchmark.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroWriteBenchmark.scala
@@ -21,11 +21,12 @@ import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConversions._
 import scala.util.Random
-
 import com.google.common.io.Files
 import org.apache.commons.io.FileUtils
 import org.apache.spark.sql._
 import org.apache.spark.sql.types._
+
+import scala.math.BigDecimal.RoundingMode
 
 /**
  * This object runs a simple benchmark test to find out how long does it take to write a large
@@ -49,7 +50,8 @@ object AvroWriteBenchmark {
 
   private def generateRandomRow(): Row = {
     val rand = new Random()
-    Row(rand.nextString(defaultSize), rand.nextInt(), new Date(rand.nextLong()) ,rand.nextDouble(), rand.nextDouble(),
+    Row(rand.nextString(defaultSize), rand.nextInt(), new Date(rand.nextLong()) ,rand.nextDouble(),
+      BigDecimal(rand.nextDouble()).setScale(10,RoundingMode.HALF_UP),
       TestUtils.generateRandomArray(rand, defaultSize).toSeq,
       TestUtils.generateRandomMap(rand, defaultSize).toMap, Row(rand.nextInt()))
   }

--- a/src/test/scala/com/databricks/spark/avro/AvroWriteBenchmark.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroWriteBenchmark.scala
@@ -51,7 +51,7 @@ object AvroWriteBenchmark {
   private def generateRandomRow(): Row = {
     val rand = new Random()
     Row(rand.nextString(defaultSize), rand.nextInt(), new Date(rand.nextLong()) ,rand.nextDouble(),
-      BigDecimal(rand.nextDouble()).setScale(10,RoundingMode.HALF_UP),
+      BigDecimal(rand.nextDouble()).setScale(10, RoundingMode.HALF_UP),
       TestUtils.generateRandomArray(rand, defaultSize).toSeq,
       TestUtils.generateRandomMap(rand, defaultSize).toMap, Row(rand.nextInt()))
   }

--- a/src/test/scala/com/databricks/spark/avro/AvroWriteBenchmark.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroWriteBenchmark.scala
@@ -50,7 +50,7 @@ object AvroWriteBenchmark {
 
   private def generateRandomRow(): Row = {
     val rand = new Random()
-    Row(rand.nextString(defaultSize), rand.nextInt(), new Date(rand.nextLong()) ,rand.nextDouble(),
+    Row(rand.nextString(defaultSize), rand.nextInt(), new Date(rand.nextLong()), rand.nextDouble(),
       BigDecimal(rand.nextDouble()).setScale(10, RoundingMode.HALF_UP),
       TestUtils.generateRandomArray(rand, defaultSize).toSeq,
       TestUtils.generateRandomMap(rand, defaultSize).toMap, Row(rand.nextInt()))


### PR DESCRIPTION
Fix java.lang.Double is not valid external type for Decimal(10,10) issue in test AvroWriteBenchmark

The previous test will throw following exception:

```java
Caused by: java.lang.RuntimeException: java.lang.Double is not a valid external type for schema of decimal(10,10)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.apply(generated.java:288)
	at org.apache.spark.sql.catalyst.encoders.ExpressionEncoder.toRow(ExpressionEncoder.scala:276)
	... 17 more
```