### PR TITLE
Add Date and Timestamp data types support when reading avro fields

### DIFF
--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -16,6 +16,8 @@
 package com.databricks.spark.avro
 
 import java.nio.ByteBuffer
+import java.sql.Timestamp
+import java.sql.Date
 
 import scala.collection.JavaConverters._
 
@@ -152,6 +154,13 @@ object SchemaConverters {
         case (IntegerType, INT) | (BooleanType, BOOLEAN) | (DoubleType, DOUBLE) |
              (FloatType, FLOAT) | (LongType, LONG) =>
           identity
+        case (TimestampType, LONG) =>
+          (item: AnyRef) => {
+            new Timestamp(item.asInstanceOf[Long])
+          }
+        case (DateType, LONG) =>
+          (item: AnyRef) =>
+            new Date(item.asInstanceOf[Long])
         case (BinaryType, FIXED) =>
           (item: AnyRef) =>
             if (item == null) {
@@ -299,7 +308,7 @@ object SchemaConverters {
         case (left, right) =>
           throw new IncompatibleSchemaException(
             s"Cannot convert Avro schema to catalyst type because schema at path " +
-              s"${path.mkString(".")} is not compatible (avroType = $left, sqlType = $right). \n" +
+              s"${path.mkString(".")} is not compatible (avroType = $right, sqlType = $left). \n" +
               s"Source Avro schema: $sourceAvroSchema.\n" +
               s"Target Catalyst type: $targetSqlType")
       }

--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -155,12 +155,9 @@ object SchemaConverters {
              (FloatType, FLOAT) | (LongType, LONG) =>
           identity
         case (TimestampType, LONG) =>
-          (item: AnyRef) => {
-            new Timestamp(item.asInstanceOf[Long])
-          }
+          (item: AnyRef) => new Timestamp(item.asInstanceOf[Long])
         case (DateType, LONG) =>
-          (item: AnyRef) =>
-            new Date(item.asInstanceOf[Long])
+          (item: AnyRef) => new Date(item.asInstanceOf[Long])
         case (BinaryType, FIXED) =>
           (item: AnyRef) =>
             if (item == null) {


### PR DESCRIPTION
Related issue: #229 
Related Spark JIRA ticket: https://issues.apache.org/jira/browse/SPARK-22460

Seems it is somehow inconvenient when reading avro files written with DataFrame with timestamp field.

It might be easier to read such data fields if we can explicitly require this data source to interpret a field as timestamp type. 

This also add the support of date type together.
