### PR TITLE
In 1.8 generated fixed types do not extend GenericData.Fixed anymore

### DIFF
--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -19,7 +19,7 @@ import java.nio.ByteBuffer
 
 import scala.collection.JavaConverters._
 
-import org.apache.avro.generic.GenericData.Fixed
+import org.apache.avro.generic.GenericFixed
 import org.apache.avro.generic.{GenericData, GenericRecord}
 import org.apache.avro.{Schema, SchemaBuilder}
 import org.apache.avro.SchemaBuilder._
@@ -157,7 +157,7 @@ object SchemaConverters {
             if (item == null) {
               null
             } else {
-              item.asInstanceOf[Fixed].bytes().clone()
+              item.asInstanceOf[GenericFixed].bytes().clone()
             }
         case (BinaryType, BYTES) =>
           (item: AnyRef) =>


### PR DESCRIPTION
Fixed types generated with the 1.8 avro code generator do not extend from `GenericData.Fixed` anymore.
This triggers a `ClassCastException` when converting an object from such a class to a `GenericRow`.

```
java.lang.ClassCastException: com.technicolor.avro.common.MacAddress cannot be cast to org.apache.avro.generic.GenericData$Fixed
        at com.databricks.spark.avro.SchemaConverters$$anonfun$com$databricks$spark$avro$SchemaConverters$$createConverter$1$3.apply(SchemaConverters.scala:160)
        at com.databricks.spark.avro.SchemaConverters$$anonfun$com$databricks$spark$avro$SchemaConverters$$createConverter$1$5.apply(SchemaConverters.scala:207)
        at com.databricks.spark.avro.SchemaConverters$$anonfun$com$databricks$spark$avro$SchemaConverters$$createConverter$1$6$$anonfun$apply$1.apply(SchemaConverters.scala:227)
        at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
        at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
        at scala.collection.Iterator$class.foreach(Iterator.scala:893)
        at scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
        at scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
        at scala.collection.AbstractIterable.foreach(Iterable.scala:54)
        at scala.collection.TraversableLike$class.map(TraversableLike.scala:234)
        at scala.collection.AbstractTraversable.map(Traversable.scala:104)
        at com.databricks.spark.avro.SchemaConverters$$anonfun$com$databricks$spark$avro$SchemaConverters$$createConverter$1$6.apply(SchemaConverters.scala:222)
        at com.databricks.spark.avro.SchemaConverters$$anonfun$com$databricks$spark$avro$SchemaConverters$$createConverter$1$5.apply(SchemaConverters.scala:207)
        at com.technicolor.doctor.hadoop.explore.SparkEventsEnvelope$AvroToRowConverter.call(SparkEventsEnvelope.java:249)
```
This problem is solved by using the GenericFixed base type.