### PR TITLE
Fix null Timestamp/Date coercion to 0 epoch.

### DIFF
--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -154,13 +154,13 @@ object SchemaConverters {
              (FloatType, FLOAT) | (LongType, LONG) =>
           identity
         case (TimestampType, LONG) =>
-          (item: AnyRef) => Option(item).map { o =>
-            new Timestamp(o.asInstanceOf[Long])
-          }.orNull
+          (item: AnyRef) => if (item != null) {
+            new Timestamp(item.asInstanceOf[Long])
+          } else null
         case (DateType, LONG) =>
-          (item: AnyRef) => Option(item).map { o =>
-            new Date(o.asInstanceOf[Long])
-          }.orNull
+          (item: AnyRef) => if (item != null) {
+            new Date(item.asInstanceOf[Long])
+          } else null
         case (BinaryType, FIXED) =>
           (item: AnyRef) =>
             if (item == null) {

--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -154,9 +154,13 @@ object SchemaConverters {
              (FloatType, FLOAT) | (LongType, LONG) =>
           identity
         case (TimestampType, LONG) =>
-          (item: AnyRef) => new Timestamp(item.asInstanceOf[Long])
+          (item: AnyRef) => Option(item).map { o =>
+            new Timestamp(o.asInstanceOf[Long])
+          }.orNull
         case (DateType, LONG) =>
-          (item: AnyRef) => new Date(item.asInstanceOf[Long])
+          (item: AnyRef) => Option(item).map { o =>
+            new Date(o.asInstanceOf[Long])
+          }.orNull
         case (BinaryType, FIXED) =>
           (item: AnyRef) =>
             if (item == null) {

--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -175,7 +175,9 @@ object SchemaConverters {
             val avroField = avroSchema.getField(sqlField.name)
             if (avroField != null) {
               val converter = (item: AnyRef) => {
-                if (item == null) item else {
+                if (item == null) {
+                  item
+                } else {
                   createConverter(avroField.schema, sqlField.dataType, path :+ sqlField.name)(item)
                 }
               }

--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -148,37 +148,23 @@ object SchemaConverters {
       (sqlType, avroType) match {
         // Avro strings are in Utf8, so we have to call toString on them
         case (StringType, STRING) | (StringType, ENUM) =>
-          (item: AnyRef) => if (item == null) null else item.toString
+          (item: AnyRef) => item.toString
         // Byte arrays are reused by avro, so we have to make a copy of them.
         case (IntegerType, INT) | (BooleanType, BOOLEAN) | (DoubleType, DOUBLE) |
              (FloatType, FLOAT) | (LongType, LONG) =>
           identity
         case (TimestampType, LONG) =>
-          (item: AnyRef) => if (item != null) {
-            new Timestamp(item.asInstanceOf[Long])
-          } else null
+          (item: AnyRef) => new Timestamp(item.asInstanceOf[Long])
         case (DateType, LONG) =>
-          (item: AnyRef) => if (item != null) {
-            new Date(item.asInstanceOf[Long])
-          } else null
+          (item: AnyRef) => new Date(item.asInstanceOf[Long])
         case (BinaryType, FIXED) =>
-          (item: AnyRef) =>
-            if (item == null) {
-              null
-            } else {
-              item.asInstanceOf[GenericFixed].bytes().clone()
-            }
+          (item: AnyRef) => item.asInstanceOf[GenericFixed].bytes().clone()
         case (BinaryType, BYTES) =>
           (item: AnyRef) =>
-            if (item == null) {
-              null
-            } else {
-              val byteBuffer = item.asInstanceOf[ByteBuffer]
-              val bytes = new Array[Byte](byteBuffer.remaining)
-              byteBuffer.get(bytes)
-              bytes
-            }
-
+            val byteBuffer = item.asInstanceOf[ByteBuffer]
+            val bytes = new Array[Byte](byteBuffer.remaining)
+            byteBuffer.get(bytes)
+            bytes
         case (struct: StructType, RECORD) =>
           val length = struct.fields.length
           val converters = new Array[AnyRef => AnyRef](length)
@@ -188,8 +174,11 @@ object SchemaConverters {
             val sqlField = struct.fields(i)
             val avroField = avroSchema.getField(sqlField.name)
             if (avroField != null) {
-              val converter = createConverter(avroField.schema(), sqlField.dataType,
-                path :+ sqlField.name)
+              val converter = (item: AnyRef) => {
+                if (item == null) item else {
+                  createConverter(avroField.schema, sqlField.dataType, path :+ sqlField.name)(item)
+                }
+              }
               converters(i) = converter
               avroFieldIndexes(i) = avroField.pos()
             } else if (!sqlField.nullable) {
@@ -202,59 +191,43 @@ object SchemaConverters {
             i += 1
           }
 
-          (item: AnyRef) => {
-            if (item == null) {
-              null
-            } else {
-              val record = item.asInstanceOf[GenericRecord]
-
-              val result = new Array[Any](length)
-              var i = 0
-              while (i < converters.length) {
-                if (converters(i) != null) {
-                  val converter = converters(i)
-                  result(i) = converter(record.get(avroFieldIndexes(i)))
-                }
-                i += 1
+          (item: AnyRef) =>
+            val record = item.asInstanceOf[GenericRecord]
+            val result = new Array[Any](length)
+            var i = 0
+            while (i < converters.length) {
+              if (converters(i) != null) {
+                val converter = converters(i)
+                result(i) = converter(record.get(avroFieldIndexes(i)))
               }
-              new GenericRow(result)
+              i += 1
             }
-          }
+            new GenericRow(result)
         case (arrayType: ArrayType, ARRAY) =>
           val elementConverter = createConverter(avroSchema.getElementType, arrayType.elementType,
             path)
           val allowsNull = arrayType.containsNull
-          (item: AnyRef) => {
-            if (item == null) {
-              null
-            } else {
-              item.asInstanceOf[java.lang.Iterable[AnyRef]].asScala.map { element =>
-                if (element == null && !allowsNull) {
-                  throw new RuntimeException(s"Array value at path ${path.mkString(".")} is not " +
-                    "allowed to be null")
-                } else {
-                  elementConverter(element)
-                }
+          (item: AnyRef) =>
+            item.asInstanceOf[java.lang.Iterable[AnyRef]].asScala.map { element =>
+              if (element == null && !allowsNull) {
+                throw new RuntimeException(s"Array value at path ${path.mkString(".")} is not " +
+                  "allowed to be null")
+              } else {
+                elementConverter(element)
               }
             }
-          }
         case (mapType: MapType, MAP) if mapType.keyType == StringType =>
           val valueConverter = createConverter(avroSchema.getValueType, mapType.valueType, path)
           val allowsNull = mapType.valueContainsNull
-          (item: AnyRef) => {
-            if (item == null) {
-              null
-            } else {
-              item.asInstanceOf[java.util.Map[AnyRef, AnyRef]].asScala.map { x =>
-                if (x._2 == null && !allowsNull) {
-                  throw new RuntimeException(s"Map value at path ${path.mkString(".")} is not " +
-                    "allowed to be null")
-                } else {
-                  (x._1.toString, valueConverter(x._2))
-                }
-              }.toMap
-            }
-          }
+          (item: AnyRef) =>
+            item.asInstanceOf[java.util.Map[AnyRef, AnyRef]].asScala.map { case (k, v) =>
+              if (v == null && !allowsNull) {
+                throw new RuntimeException(s"Map value at path ${path.mkString(".")} is not " +
+                  "allowed to be null")
+              } else {
+                (k.toString, valueConverter(v))
+              }
+            }.toMap
         case (sqlType, UNION) =>
           if (avroSchema.getTypes.asScala.exists(_.getType == NULL)) {
             val remainingUnionTypes = avroSchema.getTypes.asScala.filterNot(_.getType == NULL)
@@ -266,21 +239,17 @@ object SchemaConverters {
           } else avroSchema.getTypes.asScala.map(_.getType) match {
             case Seq(t1) => createConverter(avroSchema.getTypes.get(0), sqlType, path)
             case Seq(a, b) if Set(a, b) == Set(INT, LONG) && sqlType == LongType =>
-              (item: AnyRef) => {
+              (item: AnyRef) =>
                 item match {
-                  case null => null
                   case l: java.lang.Long => l
                   case i: java.lang.Integer => new java.lang.Long(i.longValue())
                 }
-              }
             case Seq(a, b) if Set(a, b) == Set(FLOAT, DOUBLE) && sqlType == DoubleType =>
-              (item: AnyRef) => {
+              (item: AnyRef) =>
                 item match {
-                  case null => null
                   case d: java.lang.Double => d
                   case f: java.lang.Float => new java.lang.Double(f.doubleValue())
                 }
-              }
             case other =>
               sqlType match {
                 case t: StructType if t.fields.length == avroSchema.getTypes.size =>
@@ -288,15 +257,11 @@ object SchemaConverters {
                     case (field, schema) =>
                       createConverter(schema, field.dataType, path :+ field.name)
                   }
-
-                  (item: AnyRef) => if (item == null) {
-                    null
-                  } else {
+                  (item: AnyRef) =>
                     val i = GenericData.get().resolveUnion(avroSchema, item)
                     val converted = new Array[Any](fieldConverters.length)
                     converted(i) = fieldConverters(i)(item)
                     new GenericRow(converted)
-                  }
                 case _ => throw new IncompatibleSchemaException(
                   s"Cannot convert Avro schema to catalyst type because schema at path " +
                     s"${path.mkString(".")} is not compatible " +

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -542,8 +542,8 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
       val nullTime: Timestamp = null
       val nullDate: Date = null
       val schema = StructType(Seq(
-        StructField("_1", DateType, false), 
-        StructField("_2", TimestampType, false))
+        StructField("_1", DateType, nullable = true), 
+        StructField("_2", TimestampType, nullable = true))
       )
       val writeDs = Seq((nullDate, nullTime)).toDS
 

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -534,6 +534,28 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
     }
   }
 
+  test("does not coerce null date/timestamp value to 0 epoch.") {
+    TestUtils.withTempDir { tempDir =>
+      val sparkSession = spark
+      import sparkSession.implicits._
+
+      val nullTime: Timestamp = null
+      val nullDate: Date = null
+      val schema = StructType(Seq(
+        StructField("_1", DateType, false), 
+        StructField("_2", TimestampType, false))
+      )
+      val writeDs = Seq((nullDate, nullTime)).toDS
+
+      val avroDir = tempDir + "/avro"
+      writeDs.write.avro(avroDir)
+      val readValues = spark.read.schema(schema).avro(avroDir).as[(Date, Timestamp)].collect
+
+      assert(readValues.size == 1)
+      assert(readValues.head == (nullDate, nullTime))
+    }
+  }
+
   test("support of globbed paths") {
     val e1 = spark.read.avro("*/test/resources/episodes.avro").collect()
     assert(e1.length == 8)


### PR DESCRIPTION
The current implementation of `Long` to `Date` / `Timestamp` coercion does not take into account `null` values. Due to this when a `null` is cast into a `Long`, it ends up as 0 (as Scala Long does not support `null`). This PR is a fix for that.