### PR TITLE
 TimeUnit conversion for BigQuery compatibility

### DIFF
--- a/src/main/scala/com/databricks/spark/avro/AvroOutputWriterFactory.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroOutputWriterFactory.scala
@@ -20,11 +20,13 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext
 
 import org.apache.spark.sql.execution.datasources.{OutputWriter, OutputWriterFactory}
 import org.apache.spark.sql.types.StructType
+import java.util.concurrent.TimeUnit
 
 private[avro] class AvroOutputWriterFactory(
     schema: StructType,
     recordName: String,
-    recordNamespace: String) extends OutputWriterFactory {
+    recordNamespace: String,
+    timeUnit: TimeUnit) extends OutputWriterFactory {
 
   override def getFileExtension(context: TaskAttemptContext): String = {
     ".avro"
@@ -34,6 +36,6 @@ private[avro] class AvroOutputWriterFactory(
       path: String,
       dataSchema: StructType,
       context: TaskAttemptContext): OutputWriter = {
-    new AvroOutputWriter(path, context, schema, recordName, recordNamespace)
+    new AvroOutputWriter(path, context, schema, recordName, recordNamespace, timeUnit)
   }
 }

--- a/src/main/scala/com/databricks/spark/avro/AvroOutputWriterFactory.scala
+++ b/src/main/scala/com/databricks/spark/avro/AvroOutputWriterFactory.scala
@@ -16,11 +16,12 @@
 
 package com.databricks.spark.avro
 
+import java.util.concurrent.TimeUnit
+
 import org.apache.hadoop.mapreduce.TaskAttemptContext
 
 import org.apache.spark.sql.execution.datasources.{OutputWriter, OutputWriterFactory}
 import org.apache.spark.sql.types.StructType
-import java.util.concurrent.TimeUnit
 
 private[avro] class AvroOutputWriterFactory(
     schema: StructType,

--- a/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
@@ -18,6 +18,7 @@ package com.databricks.spark.avro
 
 import java.io._
 import java.net.URI
+import java.util.concurrent.TimeUnit
 import java.util.zip.Deflater
 
 import scala.util.control.NonFatal
@@ -114,6 +115,8 @@ private[avro] class DefaultSource extends FileFormat with DataSourceRegister {
       options: Map[String, String],
       dataSchema: StructType): OutputWriterFactory = {
     val recordName = options.getOrElse("recordName", "topLevelRecord")
+    val timeUnitName = options.getOrElse("timeUnit", "milliseconds")
+    val timeUnit = TimeUnit.valueOf(timeUnitName.toUpperCase)
     val recordNamespace = options.getOrElse("recordNamespace", "")
     val build = SchemaBuilder.record(recordName).namespace(recordNamespace)
     val outputAvroSchema = SchemaConverters.convertStructToAvro(dataSchema, build, recordNamespace)
@@ -145,7 +148,7 @@ private[avro] class DefaultSource extends FileFormat with DataSourceRegister {
         log.error(s"unsupported compression codec $unknown")
     }
 
-    new AvroOutputWriterFactory(dataSchema, recordName, recordNamespace)
+    new AvroOutputWriterFactory(dataSchema, recordName, recordNamespace, timeUnit)
   }
 
   override def buildReader(


### PR DESCRIPTION
These changes allow to set option that make conversion of timestamp in long format using a specified precision, for example, microseconds.
The setting of precision option can make avro compatible with BigQuery format, that reads timestamp in microseconds.