### PR TITLE
Make it possible to load avro files from multiple paths

### DIFF
--- a/src/main/scala/com/databricks/spark/avro/package.scala
+++ b/src/main/scala/com/databricks/spark/avro/package.scala
@@ -32,5 +32,8 @@ package object avro {
    */
   implicit class AvroDataFrameReader(reader: DataFrameReader) {
     def avro: String => DataFrame = reader.format("com.databricks.spark.avro").load
+
+    @scala.annotation.varargs
+    def avro(sources: String*): DataFrame = reader.format("com.databricks.spark.avro").load(sources:_*)
   }
 }

--- a/src/main/scala/com/databricks/spark/avro/package.scala
+++ b/src/main/scala/com/databricks/spark/avro/package.scala
@@ -34,6 +34,7 @@ package object avro {
     def avro: String => DataFrame = reader.format("com.databricks.spark.avro").load
 
     @scala.annotation.varargs
-    def avro(sources: String*): DataFrame = reader.format("com.databricks.spark.avro").load(sources:_*)
+    def avro(sources: String*): DataFrame =
+      reader.format("com.databricks.spark.avro").load(sources:_*)
   }
 }

--- a/src/main/scala/com/databricks/spark/avro/package.scala
+++ b/src/main/scala/com/databricks/spark/avro/package.scala
@@ -35,6 +35,6 @@ package object avro {
 
     @scala.annotation.varargs
     def avro(sources: String*): DataFrame =
-      reader.format("com.databricks.spark.avro").load(sources:_*)
+      reader.format("com.databricks.spark.avro").load(sources: _*)
   }
 }

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -58,6 +58,12 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
     }
   }
 
+  test("reading from multiple paths") {
+    val df = spark.read.avro(episodesFile, episodesFile)
+    df.registerTempTable("avro_table")
+    assert(spark.sql("select count(*) from avro_table").collect().head === Row(16))
+  }
+
   test("reading and writing partitioned data") {
     val df = spark.read.avro(episodesFile)
     val fields = List("title", "air_date", "doctor")

--- a/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
+++ b/src/test/scala/com/databricks/spark/avro/AvroSuite.scala
@@ -60,8 +60,7 @@ class AvroSuite extends FunSuite with BeforeAndAfterAll {
 
   test("reading from multiple paths") {
     val df = spark.read.avro(episodesFile, episodesFile)
-    df.registerTempTable("avro_table")
-    assert(spark.sql("select count(*) from avro_table").collect().head === Row(16))
+    assert(df.count == 16)
   }
 
   test("reading and writing partitioned data") {


### PR DESCRIPTION
This is a handy addition to `com.databricks.spark.avro` to be able to load avro files from multiple sources, and it is also compatible with the builtin formats like json: https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala#L374