### PR TITLE
Reader writer improvements

### DIFF
--- a/src/main/scala/com/databricks/spark/avro/generic/SparkGenericDatumReader.scala
+++ b/src/main/scala/com/databricks/spark/avro/generic/SparkGenericDatumReader.scala
@@ -1,0 +1,11 @@
+package com.databricks.spark.avro.generic
+
+import org.apache.avro.Schema
+import org.apache.avro.generic.{GenericDatumReader, GenericRecord}
+
+class SparkGenericDatumReader extends GenericDatumReader[GenericRecord]{
+
+  override def findStringClass(
+    schema: Schema): Class[_] = classOf[String] // avoid utf-8 strings
+
+}

--- a/src/main/scala/com/databricks/spark/avro/generic/SparkGenericDatumReader.scala
+++ b/src/main/scala/com/databricks/spark/avro/generic/SparkGenericDatumReader.scala
@@ -3,9 +3,13 @@ package com.databricks.spark.avro.generic
 import org.apache.avro.Schema
 import org.apache.avro.generic.{GenericDatumReader, GenericRecord}
 
+/**
+  * A generic datumreader that reads strings as string instead of utf-8
+  */
 class SparkGenericDatumReader extends GenericDatumReader[GenericRecord]{
 
   override def findStringClass(
-    schema: Schema): Class[_] = classOf[String] // avoid utf-8 strings
+
+    schema: Schema): Class[_] = classOf[String]
 
 }


### PR DESCRIPTION
This pr saves on string conversions by explicitly making the generic datum reader read strings instead of utf-8. 
Also, the converter copies every object from the record read by the reader but the iterator never actually reused any record instance. Now record is reused per iterator for efficient memory reuse