### PR TITLE
Implemented logical type converters for Date, Timestamp and Decimal type

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,11 +20,11 @@ testHadoopVersion := sys.props.getOrElse("hadoop.testVersion", "2.2.0")
 
 val testAvroVersion = settingKey[String]("The version of Avro to test against.")
 
-testAvroVersion := sys.props.getOrElse("avro.testVersion", "1.7.6")
+testAvroVersion := sys.props.getOrElse("avro.testVersion", "1.8.2")
 
 val testAvroMapredVersion = settingKey[String]("The version of avro-mapred to test against.")
 
-testAvroMapredVersion := sys.props.getOrElse("avroMapred.testVersion", "1.7.7")
+testAvroMapredVersion := sys.props.getOrElse("avroMapred.testVersion", "1.8.2")
 
 spAppendScalaVersion := true
 
@@ -36,8 +36,8 @@ sparkComponents := Seq("sql")
 
 libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-api" % "1.7.5",
-  "org.apache.avro" % "avro" % "1.7.6" exclude("org.mortbay.jetty", "servlet-api"),
-  "org.apache.avro" % "avro-mapred" % "1.7.7"  % "provided" classifier("hadoop2") exclude("org.mortbay.jetty", "servlet-api"),
+  "org.apache.avro" % "avro" % "1.8.2" exclude("org.mortbay.jetty", "servlet-api"),
+  "org.apache.avro" % "avro-mapred" % "1.8.2"  % "provided" classifier("hadoop2") exclude("org.mortbay.jetty", "servlet-api"),
   // Kryo is provided by Spark, but we need this here in order to be able to import the @DefaultSerializer annotation:
   "com.esotericsoftware" % "kryo-shaded" % "3.0.3" % "provided",
   "org.scalatest" %% "scalatest" % "2.2.1" % "test",
@@ -57,6 +57,8 @@ libraryDependencies ++= Seq(
 
 // Display full-length stacktraces from ScalaTest:
 testOptions in Test += Tests.Argument("-oF")
+
+fork in Test := true
 
 scalacOptions ++= Seq("-target:jvm-1.7")
 

--- a/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/avro/DefaultSource.scala
@@ -116,7 +116,8 @@ private[avro] class DefaultSource extends FileFormat with DataSourceRegister {
     val recordName = options.getOrElse("recordName", "topLevelRecord")
     val recordNamespace = options.getOrElse("recordNamespace", "")
     val build = SchemaBuilder.record(recordName).namespace(recordNamespace)
-    val outputAvroSchema = SchemaConverters.convertStructToAvro(dataSchema, build, recordNamespace)
+    val outputAvroSchema = SchemaConverters.convertStructToAvro(dataSchema, build,
+      SchemaNsNaming.fromName(recordNamespace))
 
     AvroJob.setOutputKeySchema(job, outputAvroSchema)
     val AVRO_COMPRESSION_CODEC = "spark.sql.avro.compression.codec"

--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -73,8 +73,8 @@ object SchemaConverters {
 
     val logicalTypesConverter: PartialFunction[Schema, SchemaType] = {
       case s if LogicalTypePredicates.DECIMAL.apply(s) =>
-        val precision = s.getJsonProp("precision").asInt(DecimalType.MAX_PRECISION)
-        val scale = s.getJsonProp("scale").asInt(0)
+        val precision = s.getJsonProp("precision").asInt(DecimalType.MAX_PRECISION) min DecimalType.MAX_PRECISION
+        val scale = s.getJsonProp("scale").asInt(0) min DecimalType.MAX_SCALE
         SchemaType(DataTypes.createDecimalType(precision, scale), nullable = false)
 
       case s if LogicalTypePredicates.TIMESTAMP.apply(s) =>

--- a/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaConverters.scala
@@ -73,7 +73,8 @@ object SchemaConverters {
 
     val logicalTypesConverter: PartialFunction[Schema, SchemaType] = {
       case s if LogicalTypePredicates.DECIMAL.apply(s) =>
-        val precision = s.getJsonProp("precision").asInt(DecimalType.MAX_PRECISION) min DecimalType.MAX_PRECISION
+        val precision = s.getJsonProp("precision").asInt(DecimalType.MAX_PRECISION) min
+          DecimalType.MAX_PRECISION
         val scale = s.getJsonProp("scale").asInt(0) min DecimalType.MAX_SCALE
         SchemaType(DataTypes.createDecimalType(precision, scale), nullable = false)
 

--- a/src/main/scala/com/databricks/spark/avro/SchemaNsNaming.scala
+++ b/src/main/scala/com/databricks/spark/avro/SchemaNsNaming.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.databricks.spark.avro
+
+import org.apache.spark.sql.types.DataType
+
+/*
+ * Schema namespace naming strategies for hierarchical types such as struct, maps and arrays
+ */
+private[avro] object SchemaNsNaming {
+  def fromName(name: String): SchemaNsNaming = FlatSchemaNsNaming(name)
+
+  case class HierarchicalSchemaNsNaming(namespace: String, fieldName: String)
+    extends SchemaNsNaming {
+
+    override val currentNamespace: String =
+      if (namespace == null) fieldName else s"$namespace.$fieldName"
+  }
+
+  case class StructSchemaNsNaming(currentNamespace: String, structFieldName: String)
+    extends SchemaNsNaming
+
+  case class FlatSchemaNsNaming(currentNamespace: String) extends SchemaNsNaming
+
+}
+
+private[avro] sealed trait SchemaNsNaming {
+  import SchemaNsNaming._
+
+  def currentNamespace: String
+
+  def structFieldNaming(fieldName: String): SchemaNsNaming =
+    HierarchicalSchemaNsNaming(currentNamespace, fieldName)
+
+  def arrayFieldNaming(fieldName: String, valueType: DataType): SchemaNsNaming = this
+
+  def mapFieldNaming(fieldName: String, valueType: DataType): SchemaNsNaming = this
+}
+


### PR DESCRIPTION
I've implemented support for certain logical types according to following specification:
https://avro.apache.org/docs/1.8.0/spec.html#Logical+Types

Please note that avro library version is upgraded to 1.8 because `LogicalTypes` are not part of 1.7 package.

I've also eliminated duplication between `convertTypeToAvro` and `convertFieldTypeToAvro` by introducing SchemaNsNaming class which handles hierarchical structures.